### PR TITLE
Fix: Add missing pandas dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 
 dependencies = [
     "lancedb>=0.1.0",
+    "pandas>=2.0.0",
     "transformers>=4.30.0",
     "torch>=2.0.0",
     "click>=8.0.0",


### PR DESCRIPTION
pandas is imported in codesearch/lancedb/optimization.py but was not listed in pyproject.toml dependencies, causing ModuleNotFoundError on startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)