### PR TITLE
feat(cli): Wire up Python parser in index command

### DIFF
--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1,8 +1,10 @@
 """Tests for CLI commands."""
 
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
+
 import pytest
 from typer.testing import CliRunner
+
 from codesearch.cli.main import app
 from codesearch.query.models import SearchResult
 
@@ -152,8 +154,9 @@ def test_dependencies_no_database():
 
 def test_index_command_with_scanner(tmp_path):
     """Test index command with scanner integration."""
-    from codesearch.models import FileMetadata
     from datetime import datetime
+
+    from codesearch.models import FileMetadata
 
     # Create a real temp directory
     test_repo = tmp_path / "test_repo"
@@ -224,8 +227,9 @@ def test_index_command_no_files_found(tmp_path):
 
 def test_index_command_with_language_filter(tmp_path):
     """Test index command with language filter."""
-    from codesearch.models import FileMetadata
     from datetime import datetime
+
+    from codesearch.models import FileMetadata
 
     # Create a real temp directory
     test_repo = tmp_path / "test_repo"
@@ -289,3 +293,218 @@ def test_refactor_dupes_custom_threshold():
                 result = runner.invoke(app, ["refactor-dupes", "--threshold", "0.90"])
                 assert result.exit_code == 0
                 assert "0.9" in result.stdout
+
+
+def test_index_command_with_parser(tmp_path):
+    """Test index command with parser integration."""
+    from datetime import datetime
+
+    from codesearch.models import FileMetadata, Function
+
+    # Create a real temp directory with a Python file
+    test_repo = tmp_path / "test_repo"
+    test_repo.mkdir()
+    (test_repo / "example.py").write_text("def hello(): pass\ndef world(): pass")
+
+    mock_files = [
+        FileMetadata(
+            file_path=str(test_repo / "example.py"),
+            language="python",
+            size_bytes=50,
+            modified_time=datetime.now(),
+            is_ignored=False,
+        ),
+    ]
+
+    mock_entities = [
+        Function(
+            name="hello",
+            source_code="def hello(): pass",
+            line_number=1,
+            end_line=1,
+            file_path=str(test_repo / "example.py"),
+        ),
+        Function(
+            name="world",
+            source_code="def world(): pass",
+            line_number=2,
+            end_line=2,
+            file_path=str(test_repo / "example.py"),
+        ),
+    ]
+
+    with patch("codesearch.cli.commands.lancedb.connect"):
+        with patch("codesearch.cli.commands.get_db_path", return_value=str(tmp_path / "test.db")):
+            with patch("codesearch.cli.commands.RepositoryScannerImpl") as mock_scanner_class:
+                mock_scanner = Mock()
+                mock_scanner.scan_repository.return_value = mock_files
+                mock_scanner.get_statistics.return_value = {
+                    "total_files": 1,
+                    "by_language": {"python": 1},
+                    "total_size_bytes": 50,
+                }
+                mock_scanner.config = Mock()
+                mock_scanner_class.return_value = mock_scanner
+
+                with patch("codesearch.cli.commands.PythonParser") as mock_parser_class:
+                    mock_parser = Mock()
+                    mock_parser.parse_file.return_value = mock_entities
+                    mock_parser_class.return_value = mock_parser
+
+                    with patch("codesearch.cli.commands.Console"):
+                        result = runner.invoke(app, ["index", str(test_repo), "--force"])
+                        assert result.exit_code == 0
+                        assert "Extracted 2 code entities" in result.stdout
+                        assert "Functions/methods: 2" in result.stdout
+                        mock_parser.parse_file.assert_called_once()
+
+
+def test_index_command_parser_syntax_error(tmp_path):
+    """Test index command handles syntax errors gracefully."""
+    from datetime import datetime
+
+    from codesearch.models import FileMetadata
+
+    test_repo = tmp_path / "test_repo"
+    test_repo.mkdir()
+
+    mock_files = [
+        FileMetadata(
+            file_path=str(test_repo / "bad.py"),
+            language="python",
+            size_bytes=50,
+            modified_time=datetime.now(),
+            is_ignored=False,
+        ),
+    ]
+
+    with patch("codesearch.cli.commands.lancedb.connect"):
+        with patch("codesearch.cli.commands.get_db_path", return_value=str(tmp_path / "test.db")):
+            with patch("codesearch.cli.commands.RepositoryScannerImpl") as mock_scanner_class:
+                mock_scanner = Mock()
+                mock_scanner.scan_repository.return_value = mock_files
+                mock_scanner.get_statistics.return_value = {
+                    "total_files": 1,
+                    "by_language": {"python": 1},
+                    "total_size_bytes": 50,
+                }
+                mock_scanner.config = Mock()
+                mock_scanner_class.return_value = mock_scanner
+
+                with patch("codesearch.cli.commands.PythonParser") as mock_parser_class:
+                    mock_parser = Mock()
+                    mock_parser.parse_file.side_effect = SyntaxError("invalid syntax")
+                    mock_parser_class.return_value = mock_parser
+
+                    with patch("codesearch.cli.commands.Console"):
+                        result = runner.invoke(app, ["index", str(test_repo), "--force"])
+                        # Should exit 0 because it handled the error gracefully
+                        assert result.exit_code == 0
+                        assert "Skipped 1 files with errors" in result.stdout
+                        assert "No code entities found" in result.stdout
+
+
+def test_index_command_parser_with_classes(tmp_path):
+    """Test index command counts classes correctly."""
+    from datetime import datetime
+
+    from codesearch.models import Class, FileMetadata, Function
+
+    test_repo = tmp_path / "test_repo"
+    test_repo.mkdir()
+
+    mock_files = [
+        FileMetadata(
+            file_path=str(test_repo / "module.py"),
+            language="python",
+            size_bytes=100,
+            modified_time=datetime.now(),
+            is_ignored=False,
+        ),
+    ]
+
+    mock_entities = [
+        Class(
+            name="MyClass",
+            source_code="class MyClass: pass",
+            line_number=1,
+            end_line=1,
+            file_path=str(test_repo / "module.py"),
+        ),
+        Function(
+            name="helper",
+            source_code="def helper(): pass",
+            line_number=3,
+            end_line=3,
+            file_path=str(test_repo / "module.py"),
+        ),
+    ]
+
+    with patch("codesearch.cli.commands.lancedb.connect"):
+        with patch("codesearch.cli.commands.get_db_path", return_value=str(tmp_path / "test.db")):
+            with patch("codesearch.cli.commands.RepositoryScannerImpl") as mock_scanner_class:
+                mock_scanner = Mock()
+                mock_scanner.scan_repository.return_value = mock_files
+                mock_scanner.get_statistics.return_value = {
+                    "total_files": 1,
+                    "by_language": {"python": 1},
+                    "total_size_bytes": 100,
+                }
+                mock_scanner.config = Mock()
+                mock_scanner_class.return_value = mock_scanner
+
+                with patch("codesearch.cli.commands.PythonParser") as mock_parser_class:
+                    mock_parser = Mock()
+                    mock_parser.parse_file.return_value = mock_entities
+                    mock_parser_class.return_value = mock_parser
+
+                    with patch("codesearch.cli.commands.Console"):
+                        result = runner.invoke(app, ["index", str(test_repo), "--force"])
+                        assert result.exit_code == 0
+                        assert "Extracted 2 code entities" in result.stdout
+                        assert "Functions/methods: 1" in result.stdout
+                        assert "Classes: 1" in result.stdout
+
+
+def test_index_command_skips_non_python(tmp_path):
+    """Test index command skips non-Python files (parser only supports Python)."""
+    from datetime import datetime
+
+    from codesearch.models import FileMetadata
+
+    test_repo = tmp_path / "test_repo"
+    test_repo.mkdir()
+
+    mock_files = [
+        FileMetadata(
+            file_path=str(test_repo / "script.js"),
+            language="javascript",
+            size_bytes=50,
+            modified_time=datetime.now(),
+            is_ignored=False,
+        ),
+    ]
+
+    with patch("codesearch.cli.commands.lancedb.connect"):
+        with patch("codesearch.cli.commands.get_db_path", return_value=str(tmp_path / "test.db")):
+            with patch("codesearch.cli.commands.RepositoryScannerImpl") as mock_scanner_class:
+                mock_scanner = Mock()
+                mock_scanner.scan_repository.return_value = mock_files
+                mock_scanner.get_statistics.return_value = {
+                    "total_files": 1,
+                    "by_language": {"javascript": 1},
+                    "total_size_bytes": 50,
+                }
+                mock_scanner.config = Mock()
+                mock_scanner_class.return_value = mock_scanner
+
+                with patch("codesearch.cli.commands.PythonParser") as mock_parser_class:
+                    mock_parser = Mock()
+                    mock_parser_class.return_value = mock_parser
+
+                    with patch("codesearch.cli.commands.Console"):
+                        result = runner.invoke(app, ["index", str(test_repo), "--force"])
+                        assert result.exit_code == 0
+                        # Parser should never be called for non-Python files
+                        mock_parser.parse_file.assert_not_called()
+                        assert "No code entities found" in result.stdout


### PR DESCRIPTION
## Summary
- Integrates `PythonParser` to extract functions and classes from Python files during indexing
- Adds progress spinner during code entity extraction
- Gracefully handles syntax errors, IO errors, and other exceptions
- Reports extracted entity counts (functions vs classes)
- Reports parse errors with file paths (shows up to 5 errors)
- Skips non-Python files until additional parsers are implemented
- Adds 4 new unit tests for parser integration

## Changes
- `codesearch/cli/commands.py`: Replaced TODO placeholder with actual parser integration
- `tests/cli/test_commands.py`: Added 4 new tests:
  - `test_index_command_with_parser` - verifies parser is called and entities counted
  - `test_index_command_parser_syntax_error` - verifies graceful error handling
  - `test_index_command_parser_with_classes` - verifies correct counting of classes vs functions
  - `test_index_command_skips_non_python` - verifies non-Python files are skipped

## Test Plan
- [x] All 7 index-related tests pass
- [x] New parser integration tests pass
- [x] Lint checks pass (ruff)

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)