### PR TITLE
feat(cli): implement find-similar command with entity lookup (#55)

### DIFF
--- a/codesearch/cli/commands.py
+++ b/codesearch/cli/commands.py
@@ -98,32 +98,49 @@ def find_similar(
         client = lancedb.connect(db_path)
         engine = QueryEngine(client)
 
-        # Try to get entity vector from database
+        # Find the entity by name in the database
         try:
             entities_table = client.open_table("code_entities")
-            results = entities_table.search().limit(limit + 1).to_list()
 
-            # Filter by name and language if needed
-            matching = [r for r in results if r.get("name") == entity_name]
+            # Search for entity by name using LanceDB where clause
+            # Build filter string - escape single quotes in entity name
+            safe_name = entity_name.replace("'", "''")
+            filter_expr = f"name = '{safe_name}'"
+            if language:
+                safe_language = language.replace("'", "''")
+                filter_expr += f" AND language = '{safe_language}'"
 
-            if not matching:
+            # Query all entities matching the name
+            entity_results = (
+                entities_table.search()
+                .where(filter_expr, prefilter=True)
+                .limit(1)
+                .to_list()
+            )
+
+            if not entity_results:
                 typer.echo(f"❌ Entity '{entity_name}' not found in database")
-                raise typer.Exit(2)
+                raise typer.Exit(3)
 
-            entity = matching[0]
+            entity = entity_results[0]
+            entity_id = entity.get("entity_id")
+
             if "code_vector" not in entity or not entity["code_vector"]:
                 typer.echo(f"⚠️  Entity '{entity_name}' has no embedding vector")
                 raise typer.Exit(2)
 
-            # Search similar vectors
+            # Search for similar vectors using the entity's embedding
             typer.echo(f"🔍 Finding similar code to '{entity_name}'...")
             similar_results = engine.search_vector(
                 entity["code_vector"],
-                limit=limit + 1
+                limit=limit + 1  # +1 to account for excluding self
             )
 
-            # Filter out the original entity
-            filtered = [r for r in similar_results if r.name != entity_name][:limit]
+            # Filter out the original entity by entity_id (more reliable than name)
+            filtered = [r for r in similar_results if r.entity_id != entity_id][:limit]
+
+            # Apply similarity threshold
+            filtered = [r for r in filtered if r.similarity_score >= threshold]
 
             if not filtered:
                 typer.echo("❌ No similar results found")
@@ -137,13 +154,13 @@ def find_similar(
         except Exception as search_error:
             typer.echo(f"⚠️  Could not perform similarity search: {search_error}", err=True)
             typer.echo("Make sure entities have been indexed with embeddings", err=True)
-            raise typer.Exit(1)
+            raise typer.Exit(1) from None
 
     except typer.Exit:
         raise
     except Exception as e:
         typer.echo(f"❌ Error: {str(e)}", err=True)
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 def dependencies(


### PR DESCRIPTION
## Summary
- Use LanceDB `where` clause to find entities by name directly instead of searching with limit+1
- Escape single quotes in entity names for SQL injection safety
- Filter out original entity by entity_id (more reliable than name matching)
- Add similarity threshold filtering via `--threshold` flag (default: 0.0)
- Return exit code 3 when entity is not found in database
- Add 5 new tests for find-similar command functionality

## Test plan
- [x] `test_find_similar_command` - Basic functionality with mocked database
- [x] `test_find_similar_entity_not_found` - Returns exit code 3 when entity not found
- [x] `test_find_similar_no_database` - Returns exit code 2 when database doesn't exist
- [x] `test_find_similar_entity_no_embedding` - Handles entity without embedding vector
- [x] `test_find_similar_excludes_self` - Verifies original entity is excluded from results

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)