### PR TITLE
feat(embeddings): add model configuration system (#68)

### DIFF
--- a/codesearch/embeddings/config.py
+++ b/codesearch/embeddings/config.py
@@ -1,0 +1,239 @@
+"""Configuration system for embedding models.
+
+Supports configuration from multiple sources with priority:
+1. Explicit function arguments
+2. CLI flags (--model)
+3. Environment variables (CODESEARCH_MODEL, CODESEARCH_EMBEDDING_DEVICE)
+4. Configuration file (~/.codesearch/config.yaml)
+5. Default values
+"""
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Optional
+
+from codesearch.cli.config import get_config_file, load_config_file
+
+
+class PoolingStrategy(str, Enum):
+    """Pooling strategy for generating embeddings from token representations."""
+    MEAN = "mean"  # Average of all token embeddings (default, better for code)
+    CLS = "cls"    # Use [CLS] token embedding
+
+
+@dataclass
+class EmbeddingConfig:
+    """Configuration for an embedding model.
+
+    Attributes:
+        model_name: Short name for the model (e.g., "codebert", "unixcoder")
+        model_path: HuggingFace model ID or path (e.g., "microsoft/codebert-base")
+        dimensions: Output embedding dimensions
+        max_length: Maximum input sequence length in tokens
+        device: Compute device ("auto", "cpu", "cuda", "mps")
+        pooling: Pooling strategy for generating embeddings
+        api_key: Optional API key for API-based models (e.g., voyage-code)
+        api_endpoint: Optional API endpoint for API-based models
+    """
+    model_name: str
+    model_path: str
+    dimensions: int
+    max_length: int
+    device: str = "auto"
+    pooling: PoolingStrategy = PoolingStrategy.MEAN
+    api_key: Optional[str] = None
+    api_endpoint: Optional[str] = None
+
+    def to_dict(self) -> Dict:
+        """Convert config to dictionary for storage."""
+        return {
+            "model_name": self.model_name,
+            "model_path": self.model_path,
+            "dimensions": self.dimensions,
+            "max_length": self.max_length,
+            "device": self.device,
+            "pooling": (
+                self.pooling.value if isinstance(self.pooling, PoolingStrategy)
+                else self.pooling
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "EmbeddingConfig":
+        """Create config from dictionary."""
+        pooling = data.get("pooling", "mean")
+        if isinstance(pooling, str):
+            pooling = PoolingStrategy(pooling)
+
+        return cls(
+            model_name=data["model_name"],
+            model_path=data["model_path"],
+            dimensions=data["dimensions"],
+            max_length=data["max_length"],
+            device=data.get("device", "auto"),
+            pooling=pooling,
+            api_key=data.get("api_key"),
+            api_endpoint=data.get("api_endpoint"),
+        )
+
+
+# Model Registry - supported embedding models
+MODEL_REGISTRY: Dict[str, EmbeddingConfig] = {
+    # Microsoft CodeBERT - default, well-tested for code
+    "codebert": EmbeddingConfig(
+        model_name="codebert",
+        model_path="microsoft/codebert-base",
+        dimensions=768,
+        max_length=512,
+        pooling=PoolingStrategy.MEAN,
+    ),
+
+    # Microsoft UniXcoder - better cross-lingual code understanding
+    "unixcoder": EmbeddingConfig(
+        model_name="unixcoder",
+        model_path="microsoft/unixcoder-base",
+        dimensions=768,
+        max_length=512,
+        pooling=PoolingStrategy.MEAN,
+    ),
+
+    # Salesforce CodeT5+ 110M - encoder-decoder with strong code understanding
+    "codet5p-110m": EmbeddingConfig(
+        model_name="codet5p-110m",
+        model_path="Salesforce/codet5p-110m-embedding",
+        dimensions=256,
+        max_length=512,
+        pooling=PoolingStrategy.MEAN,
+    ),
+
+    # Salesforce CodeT5+ 220M - larger version
+    "codet5p-220m": EmbeddingConfig(
+        model_name="codet5p-220m",
+        model_path="Salesforce/codet5p-220m-embedding",
+        dimensions=768,
+        max_length=512,
+        pooling=PoolingStrategy.MEAN,
+    ),
+
+    # GraphCodeBERT - code + data flow aware
+    "graphcodebert": EmbeddingConfig(
+        model_name="graphcodebert",
+        model_path="microsoft/graphcodebert-base",
+        dimensions=768,
+        max_length=512,
+        pooling=PoolingStrategy.MEAN,
+    ),
+}
+
+# Default model name
+DEFAULT_MODEL_NAME = "codebert"
+
+
+def get_available_models() -> list[str]:
+    """Get list of available model names."""
+    return list(MODEL_REGISTRY.keys())
+
+
+def get_model_config(model_name: str) -> EmbeddingConfig:
+    """Get configuration for a registered model.
+
+    Args:
+        model_name: Name of the model (e.g., "codebert", "unixcoder")
+
+    Returns:
+        EmbeddingConfig for the model
+
+    Raises:
+        ValueError: If model is not in registry
+    """
+    if model_name not in MODEL_REGISTRY:
+        available = ", ".join(get_available_models())
+        raise ValueError(
+            f"Unknown model '{model_name}'. Available models: {available}"
+        )
+    return MODEL_REGISTRY[model_name]
+
+
+def get_embedding_config(
+    model: Optional[str] = None,
+    device: Optional[str] = None,
+) -> EmbeddingConfig:
+    """Get embedding configuration from all sources.
+
+    Priority (highest to lowest):
+    1. Explicit arguments (model, device)
+    2. Environment variables (CODESEARCH_MODEL, CODESEARCH_EMBEDDING_DEVICE)
+    3. Configuration file embedding section
+    4. Default values
+
+    Args:
+        model: Model name override
+        device: Device override
+
+    Returns:
+        EmbeddingConfig with resolved values
+    """
+    # Start with determining the model name
+    resolved_model = model
+    resolved_device = device
+
+    # Check environment variables
+    if resolved_model is None:
+        resolved_model = os.environ.get("CODESEARCH_MODEL")
+    if resolved_device is None:
+        resolved_device = os.environ.get("CODESEARCH_EMBEDDING_DEVICE")
+
+    # Check config file
+    config_file = get_config_file()
+    file_config = {}
+    if config_file:
+        try:
+            full_config = load_config_file(config_file)
+            file_config = full_config.get("embedding", {})
+        except Exception:
+            pass  # Ignore config file errors
+
+    if resolved_model is None:
+        resolved_model = file_config.get("model")
+    if resolved_device is None:
+        resolved_device = file_config.get("device")
+
+    # Use defaults if still not set
+    if resolved_model is None:
+        resolved_model = DEFAULT_MODEL_NAME
+    if resolved_device is None:
+        resolved_device = "auto"
+
+    # Get the model config from registry
+    config = get_model_config(resolved_model)
+
+    # Override device if specified
+    if resolved_device and resolved_device != config.device:
+        # Create a new config with the overridden device
+        config = EmbeddingConfig(
+            model_name=config.model_name,
+            model_path=config.model_path,
+            dimensions=config.dimensions,
+            max_length=config.max_length,
+            device=resolved_device,
+            pooling=config.pooling,
+            api_key=config.api_key,
+            api_endpoint=config.api_endpoint,
+        )
+
+    # Check for API key from environment for API-based models
+    api_key = os.environ.get("CODESEARCH_EMBEDDING_API_KEY")
+    if api_key and config.api_key is None:
+        config = EmbeddingConfig(
+            model_name=config.model_name,
+            model_path=config.model_path,
+            dimensions=config.dimensions,
+            max_length=config.max_length,
+            device=config.device,
+            pooling=config.pooling,
+            api_key=api_key,
+            api_endpoint=config.api_endpoint,
+        )
+
+    return config

--- a/tests/embeddings/test_config.py
+++ b/tests/embeddings/test_config.py
@@ -1,0 +1,217 @@
+"""Tests for embedding configuration system."""
+
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+from codesearch.embeddings.config import (
+    DEFAULT_MODEL_NAME,
+    MODEL_REGISTRY,
+    EmbeddingConfig,
+    PoolingStrategy,
+    get_available_models,
+    get_embedding_config,
+    get_model_config,
+)
+
+
+class TestEmbeddingConfig:
+    """Tests for EmbeddingConfig dataclass."""
+
+    def test_create_basic_config(self):
+        """Test creating a basic config."""
+        config = EmbeddingConfig(
+            model_name="test-model",
+            model_path="test/model",
+            dimensions=768,
+            max_length=512,
+        )
+        assert config.model_name == "test-model"
+        assert config.model_path == "test/model"
+        assert config.dimensions == 768
+        assert config.max_length == 512
+        assert config.device == "auto"
+        assert config.pooling == PoolingStrategy.MEAN
+        assert config.api_key is None
+
+    def test_config_with_all_options(self):
+        """Test creating a config with all options."""
+        config = EmbeddingConfig(
+            model_name="test-model",
+            model_path="test/model",
+            dimensions=256,
+            max_length=1024,
+            device="cuda",
+            pooling=PoolingStrategy.CLS,
+            api_key="test-key",
+            api_endpoint="https://api.test.com",
+        )
+        assert config.device == "cuda"
+        assert config.pooling == PoolingStrategy.CLS
+        assert config.api_key == "test-key"
+        assert config.api_endpoint == "https://api.test.com"
+
+    def test_to_dict(self):
+        """Test converting config to dictionary."""
+        config = EmbeddingConfig(
+            model_name="test-model",
+            model_path="test/model",
+            dimensions=768,
+            max_length=512,
+            pooling=PoolingStrategy.MEAN,
+        )
+        result = config.to_dict()
+        assert result["model_name"] == "test-model"
+        assert result["model_path"] == "test/model"
+        assert result["dimensions"] == 768
+        assert result["pooling"] == "mean"
+
+    def test_from_dict(self):
+        """Test creating config from dictionary."""
+        data = {
+            "model_name": "test-model",
+            "model_path": "test/model",
+            "dimensions": 768,
+            "max_length": 512,
+            "device": "cpu",
+            "pooling": "cls",
+        }
+        config = EmbeddingConfig.from_dict(data)
+        assert config.model_name == "test-model"
+        assert config.device == "cpu"
+        assert config.pooling == PoolingStrategy.CLS
+
+
+class TestModelRegistry:
+    """Tests for model registry."""
+
+    def test_codebert_in_registry(self):
+        """Test that CodeBERT is in the registry."""
+        assert "codebert" in MODEL_REGISTRY
+        config = MODEL_REGISTRY["codebert"]
+        assert config.model_path == "microsoft/codebert-base"
+        assert config.dimensions == 768
+
+    def test_unixcoder_in_registry(self):
+        """Test that UniXcoder is in the registry."""
+        assert "unixcoder" in MODEL_REGISTRY
+        config = MODEL_REGISTRY["unixcoder"]
+        assert config.model_path == "microsoft/unixcoder-base"
+
+    def test_codet5p_in_registry(self):
+        """Test that CodeT5+ models are in the registry."""
+        assert "codet5p-110m" in MODEL_REGISTRY
+        assert "codet5p-220m" in MODEL_REGISTRY
+
+    def test_get_available_models(self):
+        """Test getting list of available models."""
+        models = get_available_models()
+        assert "codebert" in models
+        assert "unixcoder" in models
+        assert len(models) >= 4  # At least our core models
+
+
+class TestGetModelConfig:
+    """Tests for get_model_config function."""
+
+    def test_get_valid_model(self):
+        """Test getting a valid model config."""
+        config = get_model_config("codebert")
+        assert config.model_name == "codebert"
+        assert config.model_path == "microsoft/codebert-base"
+
+    def test_get_invalid_model_raises(self):
+        """Test that invalid model raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            get_model_config("nonexistent-model")
+        assert "Unknown model" in str(exc_info.value)
+        assert "nonexistent-model" in str(exc_info.value)
+
+
+class TestGetEmbeddingConfig:
+    """Tests for get_embedding_config function."""
+
+    def test_default_model(self):
+        """Test that default model is used when nothing specified."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("codesearch.embeddings.config.get_config_file", return_value=None):
+                config = get_embedding_config()
+                assert config.model_name == DEFAULT_MODEL_NAME
+
+    def test_explicit_model_argument(self):
+        """Test that explicit model argument takes priority."""
+        config = get_embedding_config(model="unixcoder")
+        assert config.model_name == "unixcoder"
+        assert config.model_path == "microsoft/unixcoder-base"
+
+    def test_explicit_device_argument(self):
+        """Test that explicit device argument takes priority."""
+        config = get_embedding_config(model="codebert", device="cuda")
+        assert config.device == "cuda"
+
+    def test_env_var_model(self):
+        """Test that CODESEARCH_MODEL environment variable works."""
+        with patch.dict(os.environ, {"CODESEARCH_MODEL": "unixcoder"}, clear=True):
+            with patch("codesearch.embeddings.config.get_config_file", return_value=None):
+                config = get_embedding_config()
+                assert config.model_name == "unixcoder"
+
+    def test_env_var_device(self):
+        """Test that CODESEARCH_EMBEDDING_DEVICE environment variable works."""
+        with patch.dict(os.environ, {"CODESEARCH_EMBEDDING_DEVICE": "cpu"}, clear=True):
+            with patch("codesearch.embeddings.config.get_config_file", return_value=None):
+                config = get_embedding_config()
+                assert config.device == "cpu"
+
+    def test_explicit_overrides_env_var(self):
+        """Test that explicit argument overrides environment variable."""
+        with patch.dict(os.environ, {"CODESEARCH_MODEL": "codebert"}, clear=True):
+            config = get_embedding_config(model="unixcoder")
+            assert config.model_name == "unixcoder"
+
+    def test_config_file_model(self):
+        """Test that config file model setting works."""
+        mock_config = {"embedding": {"model": "graphcodebert"}}
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("codesearch.embeddings.config.get_config_file", return_value="/fake/path"):
+                with patch("codesearch.embeddings.config.load_config_file", return_value=mock_config):
+                    config = get_embedding_config()
+                    assert config.model_name == "graphcodebert"
+
+    def test_env_var_overrides_config_file(self):
+        """Test that environment variable overrides config file."""
+        mock_config = {"embedding": {"model": "graphcodebert"}}
+        with patch.dict(os.environ, {"CODESEARCH_MODEL": "unixcoder"}, clear=True):
+            with patch("codesearch.embeddings.config.get_config_file", return_value="/fake/path"):
+                with patch("codesearch.embeddings.config.load_config_file", return_value=mock_config):
+                    config = get_embedding_config()
+                    assert config.model_name == "unixcoder"
+
+    def test_api_key_from_env(self):
+        """Test that API key is read from environment variable."""
+        with patch.dict(
+            os.environ,
+            {"CODESEARCH_EMBEDDING_API_KEY": "secret-key"},
+            clear=True
+        ):
+            with patch("codesearch.embeddings.config.get_config_file", return_value=None):
+                config = get_embedding_config()
+                assert config.api_key == "secret-key"
+
+
+class TestPoolingStrategy:
+    """Tests for PoolingStrategy enum."""
+
+    def test_mean_value(self):
+        """Test MEAN pooling value."""
+        assert PoolingStrategy.MEAN.value == "mean"
+
+    def test_cls_value(self):
+        """Test CLS pooling value."""
+        assert PoolingStrategy.CLS.value == "cls"
+
+    def test_from_string(self):
+        """Test creating from string."""
+        assert PoolingStrategy("mean") == PoolingStrategy.MEAN
+        assert PoolingStrategy("cls") == PoolingStrategy.CLS


### PR DESCRIPTION
## Summary

Implements a flexible model configuration system for embeddings as requested in #68.

- **EmbeddingConfig dataclass** with model_name, model_path, dimensions, max_length, device, pooling strategy
- **Model registry** with 5 supported models: codebert (default), unixcoder, codet5p-110m, codet5p-220m, graphcodebert
- **`--model` CLI flag** for index command to select embedding model
- **Environment variable support**: `CODESEARCH_MODEL`, `CODESEARCH_EMBEDDING_DEVICE`, `CODESEARCH_EMBEDDING_API_KEY`
- **Config file support** via `~/.codesearch/config.yaml` embedding section
- **Configurable pooling strategy** (MEAN or CLS token)

### Configuration Priority (highest to lowest)
1. CLI arguments (`--model codebert`)
2. Environment variables (`CODESEARCH_MODEL=unixcoder`)
3. Config file (`~/.codesearch/config.yaml`)
4. Default values (codebert)

### Usage Examples
```bash
# Use specific model
codesearch index ./repo --model unixcoder

# Use environment variable
export CODESEARCH_MODEL=graphcodebert
codesearch index ./repo

# Check available models
codesearch index --help
```

## Test plan
- [x] EmbeddingConfig dataclass tests (creation, to_dict, from_dict)
- [x] Model registry tests (all models present, get_available_models)
- [x] get_model_config tests (valid/invalid models)
- [x] get_embedding_config tests (env vars, config file, priority)
- [x] PoolingStrategy enum tests

22 tests added, all passing.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)