### PR TITLE
feat(embeddings): Add Voyage Code 3 API embedding support (#71)

### DIFF
--- a/codesearch/embeddings/config.py
+++ b/codesearch/embeddings/config.py
@@ -134,6 +134,18 @@ MODEL_REGISTRY: Dict[str, EmbeddingConfig] = {
         max_length=512,
         pooling=PoolingStrategy.MEAN,
     ),
+
+    # Voyage Code 3 - API-based, state-of-the-art code embeddings
+    # Requires VOYAGE_API_KEY environment variable
+    "voyage-code-3": EmbeddingConfig(
+        model_name="voyage-code-3",
+        model_path="voyage-code-3",  # API model ID
+        dimensions=1024,
+        max_length=16000,  # 16K token context
+        device="api",
+        pooling=PoolingStrategy.MEAN,  # API handles pooling
+        api_endpoint="https://api.voyageai.com/v1/embeddings",
+    ),
 }
 
 # Default model name - UniXcoder provides better embeddings than CodeBERT
@@ -234,7 +246,13 @@ def get_embedding_config(
         )
 
     # Check for API key from environment for API-based models
-    api_key = os.environ.get("CODESEARCH_EMBEDDING_API_KEY")
+    # Try model-specific key first, then generic key
+    api_key = None
+    if config.model_name == "voyage-code-3":
+        api_key = os.environ.get("VOYAGE_API_KEY")
+    if not api_key:
+        api_key = os.environ.get("CODESEARCH_EMBEDDING_API_KEY")
+
     if api_key and config.api_key is None:
         config = EmbeddingConfig(
             model_name=config.model_name,

--- a/codesearch/embeddings/generator.py
+++ b/codesearch/embeddings/generator.py
@@ -1,9 +1,6 @@
-"""Embedding generation using transformer models."""
+"""Embedding generation using transformer models and APIs."""
 
 from typing import List, Optional, Union
-
-import torch
-from transformers import AutoModel, AutoTokenizer, T5EncoderModel
 
 from codesearch.embeddings.config import (
     EmbeddingConfig,
@@ -15,13 +12,16 @@ from codesearch.models import EmbeddingModel
 
 
 class EmbeddingGenerator:
-    """Generates embeddings for code using HuggingFace models.
+    """Generates embeddings for code using HuggingFace models or APIs.
 
     Supports configuration via:
     - Explicit EmbeddingConfig or model name
     - Environment variables (CODESEARCH_MODEL, CODESEARCH_EMBEDDING_DEVICE)
     - Configuration file (~/.codesearch/config.yaml)
     - Default (UniXcoder)
+
+    For API-based models (e.g., voyage-code-3), delegates to the appropriate
+    API client. For local models, uses HuggingFace transformers.
     """
 
     def __init__(
@@ -35,12 +35,44 @@ class EmbeddingGenerator:
             model_config: One of:
                 - EmbeddingConfig: Full configuration object
                 - EmbeddingModel: Legacy config object (for backwards compatibility)
-                - str: Model name (e.g., "codebert", "unixcoder")
+                - str: Model name (e.g., "codebert", "unixcoder", "voyage-code-3")
                 - None: Use environment/config file/defaults
-            device: Override device setting ("cpu", "cuda", "mps", "auto")
+            device: Override device setting ("cpu", "cuda", "mps", "auto", "api")
         """
         # Resolve configuration from all sources
         self.config = self._resolve_config(model_config, device)
+
+        # Check if this is an API-based model
+        self._api_generator = None
+        if self.config.device == "api" or self.config.model_name == "voyage-code-3":
+            self._init_api_generator()
+            self.device = "api"
+        else:
+            self._init_local_model()
+
+    def _init_api_generator(self) -> None:
+        """Initialize API-based embedding generator."""
+        if self.config.model_name == "voyage-code-3":
+            from codesearch.embeddings.voyage import VoyageEmbeddingGenerator
+
+            self._api_generator = VoyageEmbeddingGenerator(
+                api_key=self.config.api_key,
+                model=self.config.model_path,
+                dimensions=self.config.dimensions,
+            )
+        else:
+            raise ValueError(
+                f"Unknown API model: {self.config.model_name}. "
+                f"Supported API models: voyage-code-3"
+            )
+
+    def _init_local_model(self) -> None:
+        """Initialize local HuggingFace model."""
+        import torch
+        from transformers import AutoModel, AutoTokenizer, T5EncoderModel
+
+        # Store torch module for use in other methods
+        self._torch = torch
 
         # Determine actual device
         if self.config.device == "auto":
@@ -142,6 +174,10 @@ class EmbeddingGenerator:
 
     def get_model_info(self) -> dict:
         """Return model metadata."""
+        # Delegate to API generator if available
+        if self._api_generator is not None:
+            return self._api_generator.get_model_info()
+
         return {
             "name": self.config.model_name,
             "model_path": self.config.model_path,
@@ -163,8 +199,8 @@ class EmbeddingGenerator:
         """
         token_embeddings = model_output.last_hidden_state
         input_mask_expanded = attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
-        sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, 1)
-        sum_mask = torch.clamp(input_mask_expanded.sum(1), min=1e-9)
+        sum_embeddings = self._torch.sum(token_embeddings * input_mask_expanded, 1)
+        sum_mask = self._torch.clamp(input_mask_expanded.sum(1), min=1e-9)
         return sum_embeddings / sum_mask
 
     def _get_embedding(self, model_output, attention_mask):
@@ -188,6 +224,10 @@ class EmbeddingGenerator:
         Returns:
             Embedding vector (dimensions depend on model, normalized)
         """
+        # Delegate to API generator if using API-based model
+        if self._api_generator is not None:
+            return self._api_generator.embed_code(code_text)
+
         # Tokenize input
         inputs = self.tokenizer(
             code_text,
@@ -198,12 +238,12 @@ class EmbeddingGenerator:
         ).to(self.device)
 
         # Generate embedding
-        with torch.no_grad():
+        with self._torch.no_grad():
             outputs = self.model(**inputs)
             embedding = self._get_embedding(outputs, inputs["attention_mask"]).cpu()
 
         # L2 normalize
-        embedding = torch.nn.functional.normalize(embedding, p=2, dim=1)
+        embedding = self._torch.nn.functional.normalize(embedding, p=2, dim=1)
 
         return embedding[0].tolist()
 
@@ -219,6 +259,10 @@ class EmbeddingGenerator:
         if not code_texts:
             return []
 
+        # Delegate to API generator if using API-based model
+        if self._api_generator is not None:
+            return self._api_generator.embed_batch(code_texts)
+
         # Tokenize all inputs at once
         inputs = self.tokenizer(
             code_texts,
@@ -229,12 +273,12 @@ class EmbeddingGenerator:
         ).to(self.device)
 
         # Generate embeddings for all at once
-        with torch.no_grad():
+        with self._torch.no_grad():
             outputs = self.model(**inputs)
             embeddings = self._get_embedding(outputs, inputs["attention_mask"])
 
         # L2 normalize
-        embeddings = torch.nn.functional.normalize(embeddings, p=2, dim=1)
+        embeddings = self._torch.nn.functional.normalize(embeddings, p=2, dim=1)
 
         # Convert to list of lists and move to CPU
         return embeddings.cpu().tolist()

--- a/codesearch/embeddings/voyage.py
+++ b/codesearch/embeddings/voyage.py
@@ -1,0 +1,232 @@
+"""Voyage AI embedding generation for code using the Voyage Code 3 API.
+
+Voyage Code 3 is a state-of-the-art API-based code embedding model that provides:
+- 1024-dimensional embeddings (configurable via Matryoshka)
+- 16,000 token context window (vs 512 for local models)
+- Best-in-class code retrieval performance
+
+Requires: pip install voyageai
+"""
+
+import logging
+import os
+import time
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Default constants
+DEFAULT_MODEL = "voyage-code-3"
+DEFAULT_DIMENSIONS = 1024
+DEFAULT_MAX_LENGTH = 16000
+MAX_RETRIES = 3
+INITIAL_BACKOFF = 1.0  # seconds
+
+
+class VoyageAPIError(Exception):
+    """Exception raised for Voyage API errors."""
+
+    pass
+
+
+class VoyageEmbeddingGenerator:
+    """Generates embeddings using Voyage AI's Code 3 API.
+
+    Features:
+    - Rate limiting with exponential backoff
+    - Batch processing for efficiency
+    - Error handling and retries
+    - Cost estimation
+
+    Example:
+        ```python
+        generator = VoyageEmbeddingGenerator(api_key="your-key")
+        embedding = generator.embed_code("def hello(): print('world')")
+        ```
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: str = DEFAULT_MODEL,
+        dimensions: int = DEFAULT_DIMENSIONS,
+        max_retries: int = MAX_RETRIES,
+    ):
+        """Initialize the Voyage embedding generator.
+
+        Args:
+            api_key: Voyage AI API key. If not provided, looks for
+                    VOYAGE_API_KEY environment variable.
+            model: Model ID to use (default: voyage-code-3)
+            dimensions: Output embedding dimensions (default: 1024)
+            max_retries: Maximum retry attempts for rate limiting
+
+        Raises:
+            ImportError: If voyageai package is not installed
+            ValueError: If no API key is provided or found
+        """
+        # Resolve API key
+        self.api_key = api_key or os.environ.get("VOYAGE_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Voyage API key required. Set VOYAGE_API_KEY environment variable "
+                "or pass api_key parameter."
+            )
+
+        self.model = model
+        self.dimensions = dimensions
+        self.max_retries = max_retries
+
+        # Import voyageai (optional dependency)
+        try:
+            import voyageai
+
+            self.client = voyageai.Client(api_key=self.api_key)
+        except ImportError as e:
+            raise ImportError(
+                "voyageai package required for Voyage embeddings. "
+                "Install with: pip install voyageai"
+            ) from e
+
+        # Track API usage for cost estimation
+        self._total_tokens = 0
+        self._total_requests = 0
+
+    def get_model_info(self) -> dict:
+        """Return model metadata."""
+        return {
+            "name": self.model,
+            "model_path": self.model,
+            "dimensions": self.dimensions,
+            "max_length": DEFAULT_MAX_LENGTH,
+            "device": "api",
+            "pooling": "api",  # API handles pooling
+            "provider": "voyage",
+        }
+
+    def embed_code(self, code_text: str) -> List[float]:
+        """Generate embedding for a single code snippet.
+
+        Args:
+            code_text: Source code as string
+
+        Returns:
+            1024-dimensional embedding vector (normalized by API)
+
+        Raises:
+            VoyageAPIError: If API request fails after retries
+        """
+        embeddings = self._embed_with_retry([code_text])
+        return embeddings[0]
+
+    def embed_batch(self, code_texts: List[str]) -> List[List[float]]:
+        """Generate embeddings for multiple code snippets.
+
+        Args:
+            code_texts: List of code snippets
+
+        Returns:
+            List of embedding vectors
+
+        Raises:
+            VoyageAPIError: If API request fails after retries
+        """
+        if not code_texts:
+            return []
+
+        return self._embed_with_retry(code_texts)
+
+    def _embed_with_retry(self, texts: List[str]) -> List[List[float]]:
+        """Embed texts with exponential backoff retry for rate limits.
+
+        Args:
+            texts: List of texts to embed
+
+        Returns:
+            List of embeddings
+
+        Raises:
+            VoyageAPIError: If all retries are exhausted
+        """
+        last_error = None
+        backoff = INITIAL_BACKOFF
+
+        for attempt in range(self.max_retries):
+            try:
+                result = self.client.embed(
+                    texts,
+                    model=self.model,
+                    input_type="document",  # Code is treated as document
+                )
+
+                # Track usage
+                self._total_requests += 1
+                if hasattr(result, "total_tokens"):
+                    self._total_tokens += result.total_tokens
+
+                return result.embeddings
+
+            except Exception as e:
+                last_error = e
+                error_str = str(e).lower()
+
+                # Check if it's a rate limit error
+                is_rate_limit = "rate" in error_str or "429" in error_str
+
+                if is_rate_limit:
+                    if attempt < self.max_retries - 1:
+                        logger.warning(
+                            f"Rate limited, retrying in {backoff:.1f}s "
+                            f"(attempt {attempt + 1}/{self.max_retries})"
+                        )
+                        time.sleep(backoff)
+                        backoff *= 2  # Exponential backoff
+                        continue
+                    # Last attempt for rate limit - fall through to final error
+                else:
+                    # For non-rate-limit errors, raise immediately
+                    raise VoyageAPIError(f"Voyage API error: {e}") from e
+
+        raise VoyageAPIError(
+            f"Failed after {self.max_retries} retries: {last_error}"
+        ) from last_error
+
+    def get_usage_stats(self) -> dict:
+        """Get API usage statistics.
+
+        Returns:
+            Dictionary with usage stats and estimated cost
+        """
+        # Voyage Code 3 costs $0.06 per 1M tokens
+        cost_per_million = 0.06
+        estimated_cost = (self._total_tokens / 1_000_000) * cost_per_million
+
+        return {
+            "total_tokens": self._total_tokens,
+            "total_requests": self._total_requests,
+            "estimated_cost_usd": round(estimated_cost, 4),
+            "cost_per_million_tokens": cost_per_million,
+        }
+
+    def estimate_cost(self, texts: List[str]) -> dict:
+        """Estimate cost for embedding a list of texts.
+
+        Args:
+            texts: List of texts to estimate
+
+        Returns:
+            Dictionary with token count and estimated cost
+        """
+        # Rough estimate: ~4 characters per token for code
+        total_chars = sum(len(t) for t in texts)
+        estimated_tokens = total_chars // 4
+
+        cost_per_million = 0.06
+        estimated_cost = (estimated_tokens / 1_000_000) * cost_per_million
+
+        return {
+            "text_count": len(texts),
+            "total_characters": total_chars,
+            "estimated_tokens": estimated_tokens,
+            "estimated_cost_usd": round(estimated_cost, 4),
+        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ dev = [
     "mypy>=1.0.0",
     "ruff>=0.1.0",
 ]
+voyage = [
+    "voyageai>=0.2.0",
+]
 
 [project.scripts]
 codesearch = "codesearch.cli.main:app"

--- a/tests/embeddings/test_voyage.py
+++ b/tests/embeddings/test_voyage.py
@@ -1,0 +1,284 @@
+"""Tests for Voyage AI embedding generator."""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codesearch.embeddings.voyage import (
+    DEFAULT_DIMENSIONS,
+    DEFAULT_MAX_LENGTH,
+    DEFAULT_MODEL,
+    VoyageAPIError,
+    VoyageEmbeddingGenerator,
+)
+
+
+@pytest.fixture
+def mock_voyageai():
+    """Mock the voyageai module for tests."""
+    mock_module = MagicMock()
+    mock_client = MagicMock()
+    mock_module.Client.return_value = mock_client
+
+    with patch.dict(sys.modules, {"voyageai": mock_module}):
+        yield mock_module, mock_client
+
+
+class TestVoyageEmbeddingGeneratorInit:
+    """Tests for VoyageEmbeddingGenerator initialization."""
+
+    def test_init_with_api_key(self, mock_voyageai):
+        """Test initialization with explicit API key."""
+        mock_module, mock_client = mock_voyageai
+
+        generator = VoyageEmbeddingGenerator(api_key="test-key")
+
+        assert generator.api_key == "test-key"
+        assert generator.model == DEFAULT_MODEL
+        assert generator.dimensions == DEFAULT_DIMENSIONS
+        mock_module.Client.assert_called_once_with(api_key="test-key")
+
+    def test_init_from_env_var(self, mock_voyageai):
+        """Test initialization from VOYAGE_API_KEY environment variable."""
+        with patch.dict(os.environ, {"VOYAGE_API_KEY": "env-key"}):
+            generator = VoyageEmbeddingGenerator()
+            assert generator.api_key == "env-key"
+
+    def test_init_no_api_key_raises(self):
+        """Test that missing API key raises ValueError."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError) as exc_info:
+                VoyageEmbeddingGenerator()
+            assert "Voyage API key required" in str(exc_info.value)
+
+    def test_init_missing_package_raises(self):
+        """Test that missing voyageai package raises ImportError."""
+        # Temporarily remove voyageai from modules if present
+        with patch.dict(os.environ, {"VOYAGE_API_KEY": "test-key"}):
+            with patch.dict(sys.modules, {"voyageai": None}):
+                with pytest.raises(ImportError) as exc_info:
+                    VoyageEmbeddingGenerator(api_key="test-key")
+                assert "voyageai package required" in str(exc_info.value)
+
+    def test_init_custom_model(self, mock_voyageai):
+        """Test initialization with custom model."""
+        generator = VoyageEmbeddingGenerator(
+            api_key="test-key",
+            model="custom-model",
+            dimensions=512,
+        )
+
+        assert generator.model == "custom-model"
+        assert generator.dimensions == 512
+
+
+class TestVoyageEmbeddingGeneratorEmbed:
+    """Tests for embedding generation."""
+
+    def test_embed_code_single(self, mock_voyageai):
+        """Test embedding a single code snippet."""
+        mock_module, mock_client = mock_voyageai
+
+        # Mock the embed response
+        mock_result = MagicMock()
+        mock_result.embeddings = [[0.1, 0.2, 0.3]]
+        mock_result.total_tokens = 10
+        mock_client.embed.return_value = mock_result
+
+        generator = VoyageEmbeddingGenerator(api_key="test-key")
+        result = generator.embed_code("def hello(): pass")
+
+        assert result == [0.1, 0.2, 0.3]
+        mock_client.embed.assert_called_once_with(
+            ["def hello(): pass"],
+            model=DEFAULT_MODEL,
+            input_type="document",
+        )
+
+    def test_embed_batch(self, mock_voyageai):
+        """Test batch embedding."""
+        mock_module, mock_client = mock_voyageai
+
+        mock_result = MagicMock()
+        mock_result.embeddings = [[0.1, 0.2], [0.3, 0.4]]
+        mock_result.total_tokens = 20
+        mock_client.embed.return_value = mock_result
+
+        generator = VoyageEmbeddingGenerator(api_key="test-key")
+        result = generator.embed_batch(["code1", "code2"])
+
+        assert result == [[0.1, 0.2], [0.3, 0.4]]
+
+    def test_embed_batch_empty(self, mock_voyageai):
+        """Test batch embedding with empty list."""
+        generator = VoyageEmbeddingGenerator(api_key="test-key")
+        result = generator.embed_batch([])
+        assert result == []
+
+    def test_embed_with_retry_on_rate_limit(self, mock_voyageai):
+        """Test exponential backoff on rate limit errors."""
+        mock_module, mock_client = mock_voyageai
+
+        # First call raises rate limit, second succeeds
+        mock_result = MagicMock()
+        mock_result.embeddings = [[0.1]]
+        mock_result.total_tokens = 5
+        mock_client.embed.side_effect = [
+            Exception("rate limit exceeded"),
+            mock_result,
+        ]
+
+        generator = VoyageEmbeddingGenerator(api_key="test-key")
+
+        with patch("time.sleep"):  # Don't actually sleep
+            result = generator.embed_code("test")
+
+        assert result == [0.1]
+        assert mock_client.embed.call_count == 2
+
+    def test_embed_retry_exhausted(self, mock_voyageai):
+        """Test that retries are exhausted after max attempts."""
+        mock_module, mock_client = mock_voyageai
+        mock_client.embed.side_effect = Exception("rate limit 429")
+
+        generator = VoyageEmbeddingGenerator(api_key="test-key", max_retries=3)
+
+        with patch("time.sleep"):
+            with pytest.raises(VoyageAPIError) as exc_info:
+                generator.embed_code("test")
+
+        assert "Failed after 3 retries" in str(exc_info.value)
+
+    def test_non_rate_limit_error_raises_immediately(self, mock_voyageai):
+        """Test that non-rate-limit errors raise immediately."""
+        mock_module, mock_client = mock_voyageai
+        mock_client.embed.side_effect = Exception("invalid input")
+
+        generator = VoyageEmbeddingGenerator(api_key="test-key")
+
+        with pytest.raises(VoyageAPIError) as exc_info:
+            generator.embed_code("test")
+
+        assert "Voyage API error" in str(exc_info.value)
+        assert mock_client.embed.call_count == 1  # No retry
+
+
+class TestVoyageEmbeddingGeneratorInfo:
+    """Tests for model info and usage tracking."""
+
+    def test_get_model_info(self, mock_voyageai):
+        """Test getting model metadata."""
+        generator = VoyageEmbeddingGenerator(api_key="test-key")
+        info = generator.get_model_info()
+
+        assert info["name"] == DEFAULT_MODEL
+        assert info["dimensions"] == DEFAULT_DIMENSIONS
+        assert info["max_length"] == DEFAULT_MAX_LENGTH
+        assert info["device"] == "api"
+        assert info["provider"] == "voyage"
+
+    def test_get_usage_stats_initial(self, mock_voyageai):
+        """Test usage stats before any requests."""
+        generator = VoyageEmbeddingGenerator(api_key="test-key")
+        stats = generator.get_usage_stats()
+
+        assert stats["total_tokens"] == 0
+        assert stats["total_requests"] == 0
+        assert stats["estimated_cost_usd"] == 0.0
+
+    def test_usage_tracking(self, mock_voyageai):
+        """Test that usage is tracked after requests."""
+        mock_module, mock_client = mock_voyageai
+
+        mock_result = MagicMock()
+        mock_result.embeddings = [[0.1]]
+        mock_result.total_tokens = 100
+        mock_client.embed.return_value = mock_result
+
+        generator = VoyageEmbeddingGenerator(api_key="test-key")
+        generator.embed_code("test")
+
+        stats = generator.get_usage_stats()
+        assert stats["total_tokens"] == 100
+        assert stats["total_requests"] == 1
+
+    def test_estimate_cost(self, mock_voyageai):
+        """Test cost estimation."""
+        generator = VoyageEmbeddingGenerator(api_key="test-key")
+        estimate = generator.estimate_cost(["short", "longer code snippet here"])
+
+        assert estimate["text_count"] == 2
+        assert estimate["total_characters"] == 5 + 24  # 29
+        assert estimate["estimated_tokens"] == 7  # 29 // 4
+
+
+class TestVoyageModelRegistry:
+    """Tests for Voyage model in registry."""
+
+    def test_voyage_code_3_in_registry(self):
+        """Test that voyage-code-3 is in the model registry."""
+        from codesearch.embeddings.config import MODEL_REGISTRY
+
+        assert "voyage-code-3" in MODEL_REGISTRY
+        config = MODEL_REGISTRY["voyage-code-3"]
+        assert config.dimensions == 1024
+        assert config.max_length == 16000
+        assert config.device == "api"
+
+    def test_get_voyage_config(self):
+        """Test getting voyage config via get_model_config."""
+        from codesearch.embeddings.config import get_model_config
+
+        config = get_model_config("voyage-code-3")
+
+        assert config.model_name == "voyage-code-3"
+        assert config.api_endpoint == "https://api.voyageai.com/v1/embeddings"
+
+
+class TestEmbeddingGeneratorVoyageIntegration:
+    """Tests for EmbeddingGenerator with Voyage model."""
+
+    @pytest.fixture
+    def mock_voyage_env(self, mock_voyageai):
+        """Set up Voyage environment with mocked module and API key."""
+        mock_module, mock_client = mock_voyageai
+        with patch.dict(os.environ, {"VOYAGE_API_KEY": "test-api-key"}):
+            yield mock_module, mock_client
+
+    def test_generator_detects_api_model(self, mock_voyage_env):
+        """Test that EmbeddingGenerator detects API model and delegates."""
+        from codesearch.embeddings.generator import EmbeddingGenerator
+
+        generator = EmbeddingGenerator(model_config="voyage-code-3")
+
+        assert generator._api_generator is not None
+        assert generator.device == "api"
+
+    def test_generator_delegates_embed_code(self, mock_voyage_env):
+        """Test that embed_code delegates to API generator."""
+        mock_module, mock_client = mock_voyage_env
+
+        mock_result = MagicMock()
+        mock_result.embeddings = [[0.5] * 1024]
+        mock_result.total_tokens = 10
+        mock_client.embed.return_value = mock_result
+
+        from codesearch.embeddings.generator import EmbeddingGenerator
+
+        generator = EmbeddingGenerator(model_config="voyage-code-3")
+        result = generator.embed_code("def test(): pass")
+
+        assert len(result) == 1024
+        mock_client.embed.assert_called_once()
+
+    def test_generator_delegates_get_model_info(self, mock_voyage_env):
+        """Test that get_model_info delegates to API generator."""
+        from codesearch.embeddings.generator import EmbeddingGenerator
+
+        generator = EmbeddingGenerator(model_config="voyage-code-3")
+        info = generator.get_model_info()
+
+        assert info["provider"] == "voyage"
+        assert info["device"] == "api"


### PR DESCRIPTION
## Summary
- Add `VoyageEmbeddingGenerator` class for API-based embeddings using Voyage AI's voyage-code-3 model
- Integrate with existing `EmbeddingGenerator` for seamless API/local model switching
- Add optional `voyageai` dependency
- Add 20 tests with mocked API

## Changes

### New VoyageEmbeddingGenerator
- 1024-dimensional embeddings with 16K token context window (best-in-class)
- Rate limiting with exponential backoff (3 retries)
- API key via `VOYAGE_API_KEY` environment variable
- Usage tracking with cost estimation ($0.06 per 1M tokens)

### EmbeddingGenerator Integration
- Refactored to support both local HuggingFace and API-based models
- `embed_code()`, `embed_batch()`, `get_model_info()` delegate to API when configured
- Detects API model via `device="api"` or model name

### Configuration
- `voyage-code-3` added to `MODEL_REGISTRY`
- API key resolution: `VOYAGE_API_KEY` then `CODESEARCH_EMBEDDING_API_KEY`
- Optional extra: `pip install codesearch[voyage]`

## Usage

```bash
# Install with Voyage support
pip install codesearch[voyage]

# Set API key
export VOYAGE_API_KEY=your-key

# Index with voyage-code-3
codesearch index ./repo --model voyage-code-3
```

## Test plan
- [x] All 20 voyage tests pass with mocked API
- [x] All 51 embedding tests pass
- [x] Rate limiting with retry works
- [x] API key validation works
- [x] Integration with EmbeddingGenerator works

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)