### PR TITLE
feat(cli): Add embedding model benchmarking CLI command (#72)

### DIFF
--- a/codesearch/benchmarks/__init__.py
+++ b/codesearch/benchmarks/__init__.py
@@ -1,0 +1,16 @@
+"""Embedding model benchmarking module.
+
+Provides quality and performance benchmarking for embedding models.
+"""
+
+from codesearch.benchmarks.quality import QualityBenchmark, QUALITY_TEST_SUITE
+from codesearch.benchmarks.performance import PerformanceBenchmark
+from codesearch.benchmarks.runner import BenchmarkRunner, BenchmarkResult
+
+__all__ = [
+    "QualityBenchmark",
+    "PerformanceBenchmark",
+    "BenchmarkRunner",
+    "BenchmarkResult",
+    "QUALITY_TEST_SUITE",
+]

--- a/codesearch/benchmarks/performance.py
+++ b/codesearch/benchmarks/performance.py
@@ -1,0 +1,244 @@
+"""Performance benchmarking for embedding models.
+
+Measures:
+- Embedding speed (samples/second)
+- Memory usage (peak RAM)
+- Storage requirements (bytes per embedding)
+"""
+
+import time
+import tracemalloc
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional
+
+# Default code samples for benchmarking
+DEFAULT_BENCHMARK_SAMPLES = [
+    # Short functions
+    "def add(a, b): return a + b",
+    "def multiply(x, y): return x * y",
+    "def is_even(n): return n % 2 == 0",
+    # Medium functions
+    """def fibonacci(n):
+    if n <= 1:
+        return n
+    return fibonacci(n-1) + fibonacci(n-2)""",
+    """def binary_search(arr, target):
+    left, right = 0, len(arr) - 1
+    while left <= right:
+        mid = (left + right) // 2
+        if arr[mid] == target:
+            return mid
+        elif arr[mid] < target:
+            left = mid + 1
+        else:
+            right = mid - 1
+    return -1""",
+    # Longer function
+    """def quicksort(arr):
+    if len(arr) <= 1:
+        return arr
+    pivot = arr[len(arr) // 2]
+    left = [x for x in arr if x < pivot]
+    middle = [x for x in arr if x == pivot]
+    right = [x for x in arr if x > pivot]
+    return quicksort(left) + middle + quicksort(right)""",
+    # Class
+    """class Calculator:
+    def __init__(self):
+        self.result = 0
+
+    def add(self, value):
+        self.result += value
+        return self
+
+    def subtract(self, value):
+        self.result -= value
+        return self
+
+    def reset(self):
+        self.result = 0
+        return self""",
+    # JavaScript-like
+    "function greet(name) { return `Hello, ${name}!`; }",
+    # Go-like
+    "func main() { fmt.Println('Hello, World!') }",
+    # SQL-like
+    "SELECT id, name FROM users WHERE active = 1 ORDER BY created_at DESC",
+]
+
+
+@dataclass
+class PerformanceMetrics:
+    """Performance metrics for an embedding model."""
+
+    model_name: str
+    samples_count: int
+    total_time_seconds: float
+    samples_per_second: float
+    avg_time_per_sample_ms: float
+    peak_memory_mb: float
+    embedding_dimensions: int
+    storage_per_embedding_bytes: int
+    storage_per_1k_entities_mb: float
+    is_api_model: bool = False
+
+    def to_dict(self) -> Dict:
+        """Convert to dictionary."""
+        return {
+            "model_name": self.model_name,
+            "samples_count": self.samples_count,
+            "total_time_seconds": round(self.total_time_seconds, 3),
+            "samples_per_second": round(self.samples_per_second, 2),
+            "avg_time_per_sample_ms": round(self.avg_time_per_sample_ms, 2),
+            "peak_memory_mb": round(self.peak_memory_mb, 2),
+            "embedding_dimensions": self.embedding_dimensions,
+            "storage_per_embedding_bytes": self.storage_per_embedding_bytes,
+            "storage_per_1k_entities_mb": round(self.storage_per_1k_entities_mb, 2),
+            "is_api_model": self.is_api_model,
+        }
+
+
+class PerformanceBenchmark:
+    """Benchmarks embedding model performance."""
+
+    # Bytes per float32
+    BYTES_PER_FLOAT = 4
+
+    def __init__(
+        self,
+        samples: Optional[List[str]] = None,
+        warmup_runs: int = 1,
+    ):
+        """Initialize performance benchmark.
+
+        Args:
+            samples: Code samples to benchmark with
+            warmup_runs: Number of warmup runs before measurement
+        """
+        self.samples = samples or DEFAULT_BENCHMARK_SAMPLES
+        self.warmup_runs = warmup_runs
+
+    def run(
+        self,
+        model_name: str,
+        embed_func: Callable[[str], List[float]],
+        embed_batch_func: Optional[Callable[[List[str]], List[List[float]]]] = None,
+        is_api_model: bool = False,
+    ) -> PerformanceMetrics:
+        """Run performance benchmark for a model.
+
+        Args:
+            model_name: Name of the model being tested
+            embed_func: Function that takes code string and returns embedding
+            embed_batch_func: Optional batch embedding function
+            is_api_model: Whether this is an API-based model (skip memory profiling)
+
+        Returns:
+            PerformanceMetrics with results
+        """
+        # Use batch function if available, otherwise embed one by one
+        if embed_batch_func:
+            return self._run_batch(model_name, embed_batch_func, is_api_model)
+        else:
+            return self._run_single(model_name, embed_func, is_api_model)
+
+    def _run_batch(
+        self,
+        model_name: str,
+        embed_batch_func: Callable[[List[str]], List[List[float]]],
+        is_api_model: bool,
+    ) -> PerformanceMetrics:
+        """Run benchmark using batch embedding."""
+        # Warmup
+        for _ in range(self.warmup_runs):
+            _ = embed_batch_func(self.samples[:2])
+
+        # Start memory tracking (skip for API models)
+        if not is_api_model:
+            tracemalloc.start()
+
+        # Measure time
+        start_time = time.perf_counter()
+        embeddings = embed_batch_func(self.samples)
+        end_time = time.perf_counter()
+
+        # Get memory usage
+        if not is_api_model:
+            _, peak_memory = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+            peak_memory_mb = peak_memory / (1024 * 1024)
+        else:
+            peak_memory_mb = 0.0
+
+        return self._create_metrics(
+            model_name=model_name,
+            embeddings=embeddings,
+            total_time=end_time - start_time,
+            peak_memory_mb=peak_memory_mb,
+            is_api_model=is_api_model,
+        )
+
+    def _run_single(
+        self,
+        model_name: str,
+        embed_func: Callable[[str], List[float]],
+        is_api_model: bool,
+    ) -> PerformanceMetrics:
+        """Run benchmark using single embedding calls."""
+        # Warmup
+        for _ in range(self.warmup_runs):
+            _ = embed_func(self.samples[0])
+
+        # Start memory tracking (skip for API models)
+        if not is_api_model:
+            tracemalloc.start()
+
+        # Measure time
+        start_time = time.perf_counter()
+        embeddings = [embed_func(sample) for sample in self.samples]
+        end_time = time.perf_counter()
+
+        # Get memory usage
+        if not is_api_model:
+            _, peak_memory = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+            peak_memory_mb = peak_memory / (1024 * 1024)
+        else:
+            peak_memory_mb = 0.0
+
+        return self._create_metrics(
+            model_name=model_name,
+            embeddings=embeddings,
+            total_time=end_time - start_time,
+            peak_memory_mb=peak_memory_mb,
+            is_api_model=is_api_model,
+        )
+
+    def _create_metrics(
+        self,
+        model_name: str,
+        embeddings: List[List[float]],
+        total_time: float,
+        peak_memory_mb: float,
+        is_api_model: bool,
+    ) -> PerformanceMetrics:
+        """Create performance metrics from benchmark results."""
+        samples_count = len(self.samples)
+        dimensions = len(embeddings[0]) if embeddings else 0
+
+        # Calculate storage
+        storage_per_embedding = dimensions * self.BYTES_PER_FLOAT
+        storage_per_1k = (storage_per_embedding * 1000) / (1024 * 1024)
+
+        return PerformanceMetrics(
+            model_name=model_name,
+            samples_count=samples_count,
+            total_time_seconds=total_time,
+            samples_per_second=samples_count / total_time if total_time > 0 else 0,
+            avg_time_per_sample_ms=(total_time / samples_count * 1000) if samples_count > 0 else 0,
+            peak_memory_mb=peak_memory_mb,
+            embedding_dimensions=dimensions,
+            storage_per_embedding_bytes=storage_per_embedding,
+            storage_per_1k_entities_mb=storage_per_1k,
+            is_api_model=is_api_model,
+        )

--- a/codesearch/benchmarks/quality.py
+++ b/codesearch/benchmarks/quality.py
@@ -1,0 +1,282 @@
+"""Quality benchmarking for embedding models.
+
+Measures embedding quality through:
+- Same-function similarity (variable renaming should maintain similarity)
+- Different-function distinction (unrelated functions should have low similarity)
+- Cross-language similarity (equivalent code in different languages)
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+
+@dataclass
+class QualityTestCase:
+    """A single quality test case with code pairs."""
+
+    name: str
+    description: str
+    pairs: List[Tuple[str, str]]
+    expected_similarity: str  # "high", "medium", "low"
+
+
+# Quality test suite with code pairs
+QUALITY_TEST_SUITE: Dict[str, QualityTestCase] = {
+    "same_function_variants": QualityTestCase(
+        name="Same Function Variants",
+        description="Similar functions with variable renaming should have HIGH similarity",
+        pairs=[
+            (
+                "def add(a, b): return a + b",
+                "def add(x, y): return x + y",
+            ),
+            (
+                "def multiply(num1, num2):\n    result = num1 * num2\n    return result",
+                "def multiply(a, b):\n    product = a * b\n    return product",
+            ),
+            (
+                "def is_even(n): return n % 2 == 0",
+                "def is_even(number): return number % 2 == 0",
+            ),
+            (
+                "def greet(name): return f'Hello, {name}!'",
+                "def greet(person): return f'Hello, {person}!'",
+            ),
+        ],
+        expected_similarity="high",
+    ),
+    "different_functions": QualityTestCase(
+        name="Different Functions",
+        description="Unrelated functions should have LOW similarity",
+        pairs=[
+            (
+                "def add(a, b): return a + b",
+                "def fetch_user(id): return db.get(id)",
+            ),
+            (
+                "def calculate_tax(amount, rate): return amount * rate",
+                "def send_email(to, subject, body): smtp.send(to, subject, body)",
+            ),
+            (
+                "def fibonacci(n):\n    if n <= 1: return n\n    return fibonacci(n-1) + fibonacci(n-2)",
+                "def parse_json(text): return json.loads(text)",
+            ),
+            (
+                "def sort_list(items): return sorted(items)",
+                "class DatabaseConnection:\n    def __init__(self, host): self.host = host",
+            ),
+        ],
+        expected_similarity="low",
+    ),
+    "cross_language_python_js": QualityTestCase(
+        name="Cross-Language (Python/JS)",
+        description="Equivalent functions in Python and JavaScript should have MEDIUM-HIGH similarity",
+        pairs=[
+            (
+                "def greet(name): return f'Hello {name}'",
+                "function greet(name) { return `Hello ${name}` }",
+            ),
+            (
+                "def add(a, b): return a + b",
+                "function add(a, b) { return a + b; }",
+            ),
+            (
+                "def factorial(n):\n    if n <= 1: return 1\n    return n * factorial(n - 1)",
+                "function factorial(n) {\n    if (n <= 1) return 1;\n    return n * factorial(n - 1);\n}",
+            ),
+            (
+                "def filter_even(nums): return [x for x in nums if x % 2 == 0]",
+                "function filterEven(nums) { return nums.filter(x => x % 2 === 0); }",
+            ),
+        ],
+        expected_similarity="medium",
+    ),
+    "cross_language_python_go": QualityTestCase(
+        name="Cross-Language (Python/Go)",
+        description="Equivalent functions in Python and Go should have MEDIUM similarity",
+        pairs=[
+            (
+                "def add(a, b): return a + b",
+                "func add(a, b int) int { return a + b }",
+            ),
+            (
+                "def is_positive(n): return n > 0",
+                "func isPositive(n int) bool { return n > 0 }",
+            ),
+            (
+                "def max_value(a, b):\n    if a > b: return a\n    return b",
+                "func maxValue(a, b int) int {\n    if a > b { return a }\n    return b\n}",
+            ),
+        ],
+        expected_similarity="medium",
+    ),
+}
+
+
+@dataclass
+class QualityMetrics:
+    """Quality metrics for an embedding model."""
+
+    model_name: str
+    test_results: Dict[str, "TestCategoryResult"] = field(default_factory=dict)
+    overall_score: float = 0.0
+
+    def to_dict(self) -> Dict:
+        """Convert to dictionary."""
+        return {
+            "model_name": self.model_name,
+            "overall_score": round(self.overall_score, 3),
+            "test_results": {
+                name: result.to_dict()
+                for name, result in self.test_results.items()
+            },
+        }
+
+
+@dataclass
+class TestCategoryResult:
+    """Results for a single test category."""
+
+    category_name: str
+    expected_similarity: str
+    avg_similarity: float
+    min_similarity: float
+    max_similarity: float
+    pair_similarities: List[float]
+    score: float  # How well it matches expected behavior (0-1)
+
+    def to_dict(self) -> Dict:
+        """Convert to dictionary."""
+        return {
+            "category_name": self.category_name,
+            "expected_similarity": self.expected_similarity,
+            "avg_similarity": round(self.avg_similarity, 4),
+            "min_similarity": round(self.min_similarity, 4),
+            "max_similarity": round(self.max_similarity, 4),
+            "score": round(self.score, 3),
+        }
+
+
+def cosine_similarity(vec1: List[float], vec2: List[float]) -> float:
+    """Calculate cosine similarity between two vectors."""
+    a = np.array(vec1)
+    b = np.array(vec2)
+    dot_product = np.dot(a, b)
+    norm_a = np.linalg.norm(a)
+    norm_b = np.linalg.norm(b)
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return float(dot_product / (norm_a * norm_b))
+
+
+class QualityBenchmark:
+    """Benchmarks embedding model quality using test suites."""
+
+    # Thresholds for expected similarity levels
+    SIMILARITY_THRESHOLDS = {
+        "high": (0.85, 1.0),    # Expected range for "high" similarity
+        "medium": (0.5, 0.85),  # Expected range for "medium" similarity
+        "low": (0.0, 0.5),      # Expected range for "low" similarity
+    }
+
+    def __init__(
+        self,
+        test_suite: Optional[Dict[str, QualityTestCase]] = None,
+    ):
+        """Initialize quality benchmark.
+
+        Args:
+            test_suite: Custom test suite, defaults to QUALITY_TEST_SUITE
+        """
+        self.test_suite = test_suite or QUALITY_TEST_SUITE
+
+    def run(
+        self,
+        model_name: str,
+        embed_func,
+    ) -> QualityMetrics:
+        """Run quality benchmark for a model.
+
+        Args:
+            model_name: Name of the model being tested
+            embed_func: Function that takes code string and returns embedding
+
+        Returns:
+            QualityMetrics with test results
+        """
+        metrics = QualityMetrics(model_name=model_name)
+
+        total_score = 0.0
+        test_count = 0
+
+        for test_key, test_case in self.test_suite.items():
+            result = self._run_test_category(test_case, embed_func)
+            metrics.test_results[test_key] = result
+            total_score += result.score
+            test_count += 1
+
+        if test_count > 0:
+            metrics.overall_score = total_score / test_count
+
+        return metrics
+
+    def _run_test_category(
+        self,
+        test_case: QualityTestCase,
+        embed_func,
+    ) -> TestCategoryResult:
+        """Run tests for a single category."""
+        similarities = []
+
+        for code1, code2 in test_case.pairs:
+            emb1 = embed_func(code1)
+            emb2 = embed_func(code2)
+            sim = cosine_similarity(emb1, emb2)
+            similarities.append(sim)
+
+        avg_sim = sum(similarities) / len(similarities) if similarities else 0.0
+        min_sim = min(similarities) if similarities else 0.0
+        max_sim = max(similarities) if similarities else 0.0
+
+        # Calculate score based on expected similarity
+        score = self._calculate_score(avg_sim, test_case.expected_similarity)
+
+        return TestCategoryResult(
+            category_name=test_case.name,
+            expected_similarity=test_case.expected_similarity,
+            avg_similarity=avg_sim,
+            min_similarity=min_sim,
+            max_similarity=max_sim,
+            pair_similarities=similarities,
+            score=score,
+        )
+
+    def _calculate_score(self, similarity: float, expected: str) -> float:
+        """Calculate how well similarity matches expected level.
+
+        Returns a score between 0 and 1 indicating how well the
+        actual similarity matches the expected range.
+        """
+        low, high = self.SIMILARITY_THRESHOLDS.get(expected, (0.0, 1.0))
+
+        if low <= similarity <= high:
+            # Perfect match - within expected range
+            return 1.0
+        elif similarity < low:
+            # Below expected range
+            if expected == "high":
+                # For high expected, being lower is bad
+                return max(0.0, similarity / low)
+            else:
+                # For medium/low expected, being lower might be acceptable
+                return 0.8
+        else:
+            # Above expected range
+            if expected == "low":
+                # For low expected, being higher is bad
+                return max(0.0, 1.0 - (similarity - high) / (1.0 - high))
+            else:
+                # For high/medium expected, being higher is good
+                return 1.0

--- a/codesearch/benchmarks/runner.py
+++ b/codesearch/benchmarks/runner.py
@@ -1,0 +1,278 @@
+"""Benchmark runner that orchestrates quality and performance tests."""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from rich.console import Console
+from rich.table import Table
+
+from codesearch.benchmarks.performance import PerformanceMetrics, PerformanceBenchmark
+from codesearch.benchmarks.quality import QualityMetrics, QualityBenchmark
+from codesearch.embeddings.config import get_available_models, get_model_config
+
+
+@dataclass
+class BenchmarkResult:
+    """Combined benchmark results for a model."""
+
+    model_name: str
+    quality: Optional[QualityMetrics] = None
+    performance: Optional[PerformanceMetrics] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "model_name": self.model_name,
+            "quality": self.quality.to_dict() if self.quality else None,
+            "performance": self.performance.to_dict() if self.performance else None,
+        }
+
+
+class BenchmarkRunner:
+    """Runs benchmarks for embedding models."""
+
+    def __init__(
+        self,
+        models: Optional[List[str]] = None,
+        samples: Optional[List[str]] = None,
+        skip_api_models: bool = False,
+    ):
+        """Initialize benchmark runner.
+
+        Args:
+            models: List of model names to benchmark (defaults to all)
+            samples: Custom code samples for benchmarking
+            skip_api_models: Skip API-based models (e.g., voyage-code-3)
+        """
+        self.models = models or self._get_local_models(skip_api_models)
+        self.samples = samples
+        self.quality_benchmark = QualityBenchmark()
+        self.performance_benchmark = PerformanceBenchmark(samples=samples)
+        self.results: Dict[str, BenchmarkResult] = {}
+
+    def _get_local_models(self, skip_api: bool) -> List[str]:
+        """Get list of models to benchmark."""
+        all_models = get_available_models()
+        if skip_api:
+            return [m for m in all_models if get_model_config(m).device != "api"]
+        return all_models
+
+    def run(
+        self,
+        run_quality: bool = True,
+        run_performance: bool = True,
+        console: Optional[Console] = None,
+    ) -> Dict[str, BenchmarkResult]:
+        """Run benchmarks for all configured models.
+
+        Args:
+            run_quality: Whether to run quality benchmarks
+            run_performance: Whether to run performance benchmarks
+            console: Rich console for progress output
+
+        Returns:
+            Dictionary of model name to BenchmarkResult
+        """
+        console = console or Console()
+
+        for model_name in self.models:
+            console.print(f"\n[bold blue]Benchmarking {model_name}...[/bold blue]")
+
+            try:
+                result = self._benchmark_model(
+                    model_name,
+                    run_quality=run_quality,
+                    run_performance=run_performance,
+                    console=console,
+                )
+                self.results[model_name] = result
+            except Exception as e:
+                console.print(f"[red]Error benchmarking {model_name}: {e}[/red]")
+                self.results[model_name] = BenchmarkResult(model_name=model_name)
+
+        return self.results
+
+    def _benchmark_model(
+        self,
+        model_name: str,
+        run_quality: bool,
+        run_performance: bool,
+        console: Console,
+    ) -> BenchmarkResult:
+        """Benchmark a single model."""
+        from codesearch.embeddings.generator import EmbeddingGenerator
+
+        # Get model config to check if it's API-based
+        config = get_model_config(model_name)
+        is_api_model = config.device == "api"
+
+        # Create generator
+        console.print(f"  Loading model...")
+        generator = EmbeddingGenerator(model_config=model_name)
+
+        result = BenchmarkResult(model_name=model_name)
+
+        # Run quality benchmark
+        if run_quality:
+            console.print(f"  Running quality tests...")
+            result.quality = self.quality_benchmark.run(
+                model_name=model_name,
+                embed_func=generator.embed_code,
+            )
+            console.print(
+                f"  Quality score: [green]{result.quality.overall_score:.3f}[/green]"
+            )
+
+        # Run performance benchmark
+        if run_performance:
+            console.print(f"  Running performance tests...")
+            result.performance = self.performance_benchmark.run(
+                model_name=model_name,
+                embed_func=generator.embed_code,
+                embed_batch_func=generator.embed_batch,
+                is_api_model=is_api_model,
+            )
+            console.print(
+                f"  Speed: [green]{result.performance.samples_per_second:.1f} samples/s[/green]"
+            )
+
+        return result
+
+    def format_table(self, console: Optional[Console] = None) -> Table:
+        """Format results as a Rich table.
+
+        Args:
+            console: Rich console (unused but kept for consistency)
+
+        Returns:
+            Rich Table with benchmark results
+        """
+        table = Table(title="Embedding Model Benchmark Results")
+
+        table.add_column("Model", style="cyan", no_wrap=True)
+        table.add_column("Quality", justify="center")
+        table.add_column("Speed", justify="right")
+        table.add_column("Memory", justify="right")
+        table.add_column("Dims", justify="right")
+        table.add_column("Storage/1K", justify="right")
+
+        for model_name, result in self.results.items():
+            quality_str = self._format_quality_score(result.quality)
+            speed_str = self._format_speed(result.performance)
+            memory_str = self._format_memory(result.performance)
+            dims_str = str(result.performance.embedding_dimensions) if result.performance else "N/A"
+            storage_str = self._format_storage(result.performance)
+
+            table.add_row(
+                model_name,
+                quality_str,
+                speed_str,
+                memory_str,
+                dims_str,
+                storage_str,
+            )
+
+        return table
+
+    def _format_quality_score(self, quality: Optional[QualityMetrics]) -> str:
+        """Format quality score with stars."""
+        if not quality:
+            return "N/A"
+
+        score = quality.overall_score
+        # Convert 0-1 score to 1-5 stars
+        stars = min(5, max(1, int(score * 5) + 1))
+        return "⭐" * stars
+
+    def _format_speed(self, perf: Optional[PerformanceMetrics]) -> str:
+        """Format speed metric."""
+        if not perf:
+            return "N/A"
+        if perf.is_api_model:
+            return "API"
+        return f"{perf.samples_per_second:.1f}/s"
+
+    def _format_memory(self, perf: Optional[PerformanceMetrics]) -> str:
+        """Format memory metric."""
+        if not perf:
+            return "N/A"
+        if perf.is_api_model:
+            return "N/A"
+        return f"{perf.peak_memory_mb:.0f} MB"
+
+    def _format_storage(self, perf: Optional[PerformanceMetrics]) -> str:
+        """Format storage metric."""
+        if not perf:
+            return "N/A"
+        return f"{perf.storage_per_1k_entities_mb:.1f} MB"
+
+    def format_json(self) -> str:
+        """Format results as JSON.
+
+        Returns:
+            JSON string with all benchmark results
+        """
+        output = {
+            "benchmark_results": {
+                name: result.to_dict()
+                for name, result in self.results.items()
+            }
+        }
+        return json.dumps(output, indent=2)
+
+    def save_results(self, path: Path) -> None:
+        """Save results to JSON file.
+
+        Args:
+            path: Path to save JSON file
+        """
+        path.write_text(self.format_json())
+
+    @classmethod
+    def load_results(cls, path: Path) -> "BenchmarkRunner":
+        """Load results from JSON file.
+
+        Args:
+            path: Path to JSON file
+
+        Returns:
+            BenchmarkRunner with loaded results
+        """
+        data = json.loads(path.read_text())
+        runner = cls(models=[])
+
+        for name, result_data in data.get("benchmark_results", {}).items():
+            quality_data = result_data.get("quality")
+            perf_data = result_data.get("performance")
+
+            quality = None
+            if quality_data:
+                quality = QualityMetrics(
+                    model_name=quality_data["model_name"],
+                    overall_score=quality_data["overall_score"],
+                )
+
+            perf = None
+            if perf_data:
+                perf = PerformanceMetrics(
+                    model_name=perf_data["model_name"],
+                    samples_count=perf_data["samples_count"],
+                    total_time_seconds=perf_data["total_time_seconds"],
+                    samples_per_second=perf_data["samples_per_second"],
+                    avg_time_per_sample_ms=perf_data["avg_time_per_sample_ms"],
+                    peak_memory_mb=perf_data["peak_memory_mb"],
+                    embedding_dimensions=perf_data["embedding_dimensions"],
+                    storage_per_embedding_bytes=perf_data["storage_per_embedding_bytes"],
+                    storage_per_1k_entities_mb=perf_data["storage_per_1k_entities_mb"],
+                    is_api_model=perf_data.get("is_api_model", False),
+                )
+
+            runner.results[name] = BenchmarkResult(
+                model_name=name,
+                quality=quality,
+                performance=perf,
+            )
+
+        return runner

--- a/codesearch/cli/main.py
+++ b/codesearch/cli/main.py
@@ -9,7 +9,7 @@ from typing import Annotated, Optional
 from codesearch import __version__
 from codesearch.cli.commands import (
     pattern, find_similar, dependencies, index, refactor_dupes, list_functions,
-    repo_list, repo_add, repo_remove, search_multi
+    repo_list, repo_add, repo_remove, search_multi, benchmark_models
 )
 from codesearch.cli.interactive import (
     detail, context, compare, config_show, config_init
@@ -68,6 +68,9 @@ app.command(name="repo-list")(repo_list)
 app.command(name="repo-add")(repo_add)
 app.command(name="repo-remove")(repo_remove)
 app.command(name="search-multi")(search_multi)
+
+# Register benchmark commands
+app.command(name="benchmark-models")(benchmark_models)
 
 
 def run() -> None:

--- a/tests/benchmarks/__init__.py
+++ b/tests/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for embedding model benchmarking module."""

--- a/tests/benchmarks/test_performance.py
+++ b/tests/benchmarks/test_performance.py
@@ -1,0 +1,190 @@
+"""Tests for performance benchmarking."""
+
+import pytest
+
+from codesearch.benchmarks.performance import (
+    PerformanceBenchmark,
+    PerformanceMetrics,
+    DEFAULT_BENCHMARK_SAMPLES,
+)
+
+
+class TestDefaultSamples:
+    """Tests for default benchmark samples."""
+
+    def test_samples_exist(self):
+        """Default samples should exist."""
+        assert len(DEFAULT_BENCHMARK_SAMPLES) > 0
+
+    def test_samples_are_strings(self):
+        """All samples should be strings."""
+        for sample in DEFAULT_BENCHMARK_SAMPLES:
+            assert isinstance(sample, str)
+
+    def test_samples_not_empty(self):
+        """Samples should not be empty."""
+        for sample in DEFAULT_BENCHMARK_SAMPLES:
+            assert len(sample.strip()) > 0
+
+
+class TestPerformanceMetrics:
+    """Tests for PerformanceMetrics dataclass."""
+
+    def test_to_dict(self):
+        """to_dict should convert metrics to dictionary."""
+        metrics = PerformanceMetrics(
+            model_name="test-model",
+            samples_count=10,
+            total_time_seconds=1.5,
+            samples_per_second=6.67,
+            avg_time_per_sample_ms=150.0,
+            peak_memory_mb=512.0,
+            embedding_dimensions=768,
+            storage_per_embedding_bytes=3072,
+            storage_per_1k_entities_mb=2.93,
+            is_api_model=False,
+        )
+
+        result = metrics.to_dict()
+        assert result["model_name"] == "test-model"
+        assert result["samples_count"] == 10
+        assert result["embedding_dimensions"] == 768
+        assert result["is_api_model"] is False
+
+    def test_to_dict_api_model(self):
+        """to_dict should handle API model flag."""
+        metrics = PerformanceMetrics(
+            model_name="voyage-code-3",
+            samples_count=10,
+            total_time_seconds=2.0,
+            samples_per_second=5.0,
+            avg_time_per_sample_ms=200.0,
+            peak_memory_mb=0.0,
+            embedding_dimensions=1024,
+            storage_per_embedding_bytes=4096,
+            storage_per_1k_entities_mb=3.91,
+            is_api_model=True,
+        )
+
+        result = metrics.to_dict()
+        assert result["is_api_model"] is True
+
+
+class TestPerformanceBenchmark:
+    """Tests for PerformanceBenchmark class."""
+
+    @pytest.fixture
+    def mock_embed_func(self):
+        """Create a mock embedding function."""
+        def embed(code: str):
+            return [0.1] * 768
+        return embed
+
+    @pytest.fixture
+    def mock_batch_embed_func(self):
+        """Create a mock batch embedding function."""
+        def embed_batch(codes):
+            return [[0.1] * 768 for _ in codes]
+        return embed_batch
+
+    def test_run_with_single_embed(self, mock_embed_func):
+        """Run should work with single embedding function."""
+        benchmark = PerformanceBenchmark(
+            samples=["def test(): pass", "def other(): pass"],
+            warmup_runs=0,
+        )
+        metrics = benchmark.run("test-model", mock_embed_func)
+
+        assert isinstance(metrics, PerformanceMetrics)
+        assert metrics.model_name == "test-model"
+        assert metrics.samples_count == 2
+        assert metrics.embedding_dimensions == 768
+
+    def test_run_with_batch_embed(self, mock_embed_func, mock_batch_embed_func):
+        """Run should prefer batch embedding when available."""
+        benchmark = PerformanceBenchmark(
+            samples=["def test(): pass"],
+            warmup_runs=0,
+        )
+        metrics = benchmark.run(
+            "test-model",
+            mock_embed_func,
+            embed_batch_func=mock_batch_embed_func,
+        )
+
+        assert isinstance(metrics, PerformanceMetrics)
+        assert metrics.embedding_dimensions == 768
+
+    def test_run_measures_time(self, mock_embed_func):
+        """Run should measure time."""
+        benchmark = PerformanceBenchmark(
+            samples=["def test(): pass"],
+            warmup_runs=0,
+        )
+        metrics = benchmark.run("test-model", mock_embed_func)
+
+        assert metrics.total_time_seconds > 0
+        assert metrics.samples_per_second > 0
+        assert metrics.avg_time_per_sample_ms > 0
+
+    def test_run_api_model_skips_memory(self, mock_embed_func):
+        """API models should skip memory profiling."""
+        benchmark = PerformanceBenchmark(
+            samples=["def test(): pass"],
+            warmup_runs=0,
+        )
+        metrics = benchmark.run(
+            "test-model",
+            mock_embed_func,
+            is_api_model=True,
+        )
+
+        assert metrics.is_api_model is True
+        assert metrics.peak_memory_mb == 0.0
+
+    def test_custom_samples(self, mock_embed_func):
+        """Should support custom samples."""
+        custom_samples = ["print('hello')", "x = 1 + 2"]
+        benchmark = PerformanceBenchmark(samples=custom_samples, warmup_runs=0)
+        metrics = benchmark.run("test-model", mock_embed_func)
+
+        assert metrics.samples_count == 2
+
+    def test_storage_calculation(self, mock_embed_func):
+        """Storage should be calculated correctly."""
+        benchmark = PerformanceBenchmark(
+            samples=["def test(): pass"],
+            warmup_runs=0,
+        )
+        metrics = benchmark.run("test-model", mock_embed_func)
+
+        # 768 dimensions * 4 bytes = 3072 bytes
+        assert metrics.storage_per_embedding_bytes == 768 * 4
+        # 3072 * 1000 / 1024 / 1024 ≈ 2.93 MB
+        assert metrics.storage_per_1k_entities_mb == pytest.approx(2.93, rel=0.01)
+
+
+class TestStorageCalculations:
+    """Tests for storage calculation."""
+
+    def test_bytes_per_float(self):
+        """Should use 4 bytes per float32."""
+        assert PerformanceBenchmark.BYTES_PER_FLOAT == 4
+
+    def test_256_dim_storage(self):
+        """256-dim embeddings should use ~1MB per 1K entities."""
+        # 256 * 4 * 1000 / 1024 / 1024 = 0.9765 MB
+        expected = (256 * 4 * 1000) / (1024 * 1024)
+        assert expected == pytest.approx(0.976, rel=0.01)
+
+    def test_768_dim_storage(self):
+        """768-dim embeddings should use ~3MB per 1K entities."""
+        # 768 * 4 * 1000 / 1024 / 1024 = 2.93 MB
+        expected = (768 * 4 * 1000) / (1024 * 1024)
+        assert expected == pytest.approx(2.93, rel=0.01)
+
+    def test_1024_dim_storage(self):
+        """1024-dim embeddings should use ~4MB per 1K entities."""
+        # 1024 * 4 * 1000 / 1024 / 1024 = 3.90625 MB
+        expected = (1024 * 4 * 1000) / (1024 * 1024)
+        assert expected == pytest.approx(3.91, rel=0.01)

--- a/tests/benchmarks/test_quality.py
+++ b/tests/benchmarks/test_quality.py
@@ -1,0 +1,221 @@
+"""Tests for quality benchmarking."""
+
+import pytest
+
+from codesearch.benchmarks.quality import (
+    QualityBenchmark,
+    QualityMetrics,
+    QualityTestCase,
+    TestCategoryResult,
+    cosine_similarity,
+    QUALITY_TEST_SUITE,
+)
+
+
+class TestCosineSimilarity:
+    """Tests for cosine similarity calculation."""
+
+    def test_identical_vectors(self):
+        """Identical vectors should have similarity 1.0."""
+        vec = [1.0, 2.0, 3.0]
+        assert cosine_similarity(vec, vec) == pytest.approx(1.0)
+
+    def test_orthogonal_vectors(self):
+        """Orthogonal vectors should have similarity 0.0."""
+        vec1 = [1.0, 0.0]
+        vec2 = [0.0, 1.0]
+        assert cosine_similarity(vec1, vec2) == pytest.approx(0.0)
+
+    def test_opposite_vectors(self):
+        """Opposite vectors should have similarity -1.0."""
+        vec1 = [1.0, 0.0]
+        vec2 = [-1.0, 0.0]
+        assert cosine_similarity(vec1, vec2) == pytest.approx(-1.0)
+
+    def test_similar_vectors(self):
+        """Similar vectors should have high similarity."""
+        vec1 = [1.0, 2.0, 3.0]
+        vec2 = [1.1, 2.1, 3.1]
+        sim = cosine_similarity(vec1, vec2)
+        assert sim > 0.99
+
+    def test_zero_vector(self):
+        """Zero vector should return 0 similarity."""
+        vec1 = [0.0, 0.0, 0.0]
+        vec2 = [1.0, 2.0, 3.0]
+        assert cosine_similarity(vec1, vec2) == 0.0
+
+
+class TestQualityTestSuite:
+    """Tests for the quality test suite."""
+
+    def test_suite_has_categories(self):
+        """Test suite should have multiple categories."""
+        assert len(QUALITY_TEST_SUITE) >= 3
+
+    def test_same_function_variants_exists(self):
+        """Same function variants category should exist."""
+        assert "same_function_variants" in QUALITY_TEST_SUITE
+        test_case = QUALITY_TEST_SUITE["same_function_variants"]
+        assert test_case.expected_similarity == "high"
+        assert len(test_case.pairs) >= 2
+
+    def test_different_functions_exists(self):
+        """Different functions category should exist."""
+        assert "different_functions" in QUALITY_TEST_SUITE
+        test_case = QUALITY_TEST_SUITE["different_functions"]
+        assert test_case.expected_similarity == "low"
+
+    def test_cross_language_exists(self):
+        """Cross-language category should exist."""
+        assert "cross_language_python_js" in QUALITY_TEST_SUITE
+        test_case = QUALITY_TEST_SUITE["cross_language_python_js"]
+        assert test_case.expected_similarity == "medium"
+
+
+class TestQualityBenchmark:
+    """Tests for QualityBenchmark class."""
+
+    @pytest.fixture
+    def mock_embed_func(self):
+        """Create a mock embedding function."""
+        # Simple mock that returns different embeddings for different code
+        def embed(code: str):
+            # Create a simple hash-based embedding
+            import hashlib
+            h = hashlib.md5(code.encode()).hexdigest()
+            # Convert hex to floats
+            return [int(h[i:i+2], 16) / 255.0 for i in range(0, 32, 2)]
+        return embed
+
+    @pytest.fixture
+    def constant_embed_func(self):
+        """Create an embedding function that returns constant values."""
+        def embed(code: str):
+            return [0.5] * 16
+        return embed
+
+    def test_run_returns_metrics(self, mock_embed_func):
+        """Run should return QualityMetrics."""
+        benchmark = QualityBenchmark()
+        metrics = benchmark.run("test-model", mock_embed_func)
+
+        assert isinstance(metrics, QualityMetrics)
+        assert metrics.model_name == "test-model"
+        assert 0.0 <= metrics.overall_score <= 1.0
+
+    def test_run_includes_all_categories(self, mock_embed_func):
+        """Run should include results for all test categories."""
+        benchmark = QualityBenchmark()
+        metrics = benchmark.run("test-model", mock_embed_func)
+
+        for key in QUALITY_TEST_SUITE:
+            assert key in metrics.test_results
+
+    def test_custom_test_suite(self, mock_embed_func):
+        """Should support custom test suite."""
+        custom_suite = {
+            "custom_test": QualityTestCase(
+                name="Custom Test",
+                description="Test description",
+                pairs=[("def a(): pass", "def b(): pass")],
+                expected_similarity="high",
+            )
+        }
+        benchmark = QualityBenchmark(test_suite=custom_suite)
+        metrics = benchmark.run("test-model", mock_embed_func)
+
+        assert "custom_test" in metrics.test_results
+        assert len(metrics.test_results) == 1
+
+    def test_constant_embeddings_same_similarity(self, constant_embed_func):
+        """Constant embeddings should give perfect similarity."""
+        benchmark = QualityBenchmark()
+        metrics = benchmark.run("test-model", constant_embed_func)
+
+        # All pairs should have similarity 1.0
+        for result in metrics.test_results.values():
+            assert result.avg_similarity == pytest.approx(1.0)
+
+
+class TestQualityMetrics:
+    """Tests for QualityMetrics dataclass."""
+
+    def test_to_dict(self):
+        """to_dict should convert metrics to dictionary."""
+        metrics = QualityMetrics(
+            model_name="test-model",
+            overall_score=0.85,
+            test_results={
+                "test1": TestCategoryResult(
+                    category_name="Test 1",
+                    expected_similarity="high",
+                    avg_similarity=0.9,
+                    min_similarity=0.85,
+                    max_similarity=0.95,
+                    pair_similarities=[0.85, 0.9, 0.95],
+                    score=0.9,
+                )
+            },
+        )
+
+        result = metrics.to_dict()
+        assert result["model_name"] == "test-model"
+        assert result["overall_score"] == 0.85
+        assert "test1" in result["test_results"]
+
+
+class TestTestCategoryResult:
+    """Tests for TestCategoryResult dataclass."""
+
+    def test_to_dict(self):
+        """to_dict should convert result to dictionary."""
+        result = TestCategoryResult(
+            category_name="Test Category",
+            expected_similarity="high",
+            avg_similarity=0.9,
+            min_similarity=0.85,
+            max_similarity=0.95,
+            pair_similarities=[0.85, 0.9, 0.95],
+            score=0.9,
+        )
+
+        d = result.to_dict()
+        assert d["category_name"] == "Test Category"
+        assert d["expected_similarity"] == "high"
+        assert d["avg_similarity"] == 0.9
+        assert d["score"] == 0.9
+
+
+class TestScoreCalculation:
+    """Tests for score calculation logic."""
+
+    def test_high_similarity_in_range(self):
+        """High similarity in expected range should score 1.0."""
+        benchmark = QualityBenchmark()
+        score = benchmark._calculate_score(0.9, "high")
+        assert score == 1.0
+
+    def test_high_similarity_below_range(self):
+        """High similarity below range should penalize."""
+        benchmark = QualityBenchmark()
+        score = benchmark._calculate_score(0.5, "high")
+        assert score < 1.0
+
+    def test_low_similarity_in_range(self):
+        """Low similarity in expected range should score 1.0."""
+        benchmark = QualityBenchmark()
+        score = benchmark._calculate_score(0.3, "low")
+        assert score == 1.0
+
+    def test_low_similarity_above_range(self):
+        """Low similarity above range should penalize."""
+        benchmark = QualityBenchmark()
+        score = benchmark._calculate_score(0.8, "low")
+        assert score < 1.0
+
+    def test_medium_similarity_in_range(self):
+        """Medium similarity in expected range should score 1.0."""
+        benchmark = QualityBenchmark()
+        score = benchmark._calculate_score(0.65, "medium")
+        assert score == 1.0

--- a/tests/benchmarks/test_runner.py
+++ b/tests/benchmarks/test_runner.py
@@ -1,0 +1,251 @@
+"""Tests for benchmark runner."""
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codesearch.benchmarks.runner import (
+    BenchmarkResult,
+    BenchmarkRunner,
+)
+from codesearch.benchmarks.performance import PerformanceMetrics
+from codesearch.benchmarks.quality import QualityMetrics
+
+
+class TestBenchmarkResult:
+    """Tests for BenchmarkResult dataclass."""
+
+    def test_to_dict_empty(self):
+        """to_dict should work with empty results."""
+        result = BenchmarkResult(model_name="test-model")
+        d = result.to_dict()
+
+        assert d["model_name"] == "test-model"
+        assert d["quality"] is None
+        assert d["performance"] is None
+
+    def test_to_dict_with_quality(self):
+        """to_dict should include quality metrics."""
+        quality = QualityMetrics(model_name="test-model", overall_score=0.85)
+        result = BenchmarkResult(model_name="test-model", quality=quality)
+        d = result.to_dict()
+
+        assert d["quality"] is not None
+        assert d["quality"]["overall_score"] == 0.85
+
+    def test_to_dict_with_performance(self):
+        """to_dict should include performance metrics."""
+        perf = PerformanceMetrics(
+            model_name="test-model",
+            samples_count=10,
+            total_time_seconds=1.0,
+            samples_per_second=10.0,
+            avg_time_per_sample_ms=100.0,
+            peak_memory_mb=512.0,
+            embedding_dimensions=768,
+            storage_per_embedding_bytes=3072,
+            storage_per_1k_entities_mb=2.93,
+        )
+        result = BenchmarkResult(model_name="test-model", performance=perf)
+        d = result.to_dict()
+
+        assert d["performance"] is not None
+        assert d["performance"]["samples_per_second"] == 10.0
+
+
+class TestBenchmarkRunner:
+    """Tests for BenchmarkRunner class."""
+
+    @pytest.fixture
+    def mock_generator(self):
+        """Create a mock EmbeddingGenerator."""
+        mock = MagicMock()
+        mock.embed_code.return_value = [0.1] * 768
+        mock.embed_batch.return_value = [[0.1] * 768 for _ in range(10)]
+        return mock
+
+    def test_init_default_models(self):
+        """Should use local models by default."""
+        with patch("codesearch.benchmarks.runner.get_available_models") as mock:
+            mock.return_value = ["codebert", "unixcoder", "voyage-code-3"]
+            with patch("codesearch.benchmarks.runner.get_model_config") as mock_config:
+                # Make voyage-code-3 an API model
+                def get_config(name):
+                    config = MagicMock()
+                    config.device = "api" if name == "voyage-code-3" else "auto"
+                    return config
+                mock_config.side_effect = get_config
+
+                runner = BenchmarkRunner(skip_api_models=True)
+                assert "voyage-code-3" not in runner.models
+                assert "codebert" in runner.models
+
+    def test_init_with_custom_models(self):
+        """Should use custom model list when provided."""
+        runner = BenchmarkRunner(models=["codebert"])
+        assert runner.models == ["codebert"]
+
+    def test_format_json(self):
+        """format_json should return valid JSON."""
+        runner = BenchmarkRunner(models=[])
+        runner.results["test-model"] = BenchmarkResult(model_name="test-model")
+
+        json_str = runner.format_json()
+        data = json.loads(json_str)
+
+        assert "benchmark_results" in data
+        assert "test-model" in data["benchmark_results"]
+
+    def test_format_table(self):
+        """format_table should return a Rich Table."""
+        from rich.table import Table
+
+        runner = BenchmarkRunner(models=[])
+        perf = PerformanceMetrics(
+            model_name="test-model",
+            samples_count=10,
+            total_time_seconds=1.0,
+            samples_per_second=10.0,
+            avg_time_per_sample_ms=100.0,
+            peak_memory_mb=512.0,
+            embedding_dimensions=768,
+            storage_per_embedding_bytes=3072,
+            storage_per_1k_entities_mb=2.93,
+        )
+        runner.results["test-model"] = BenchmarkResult(
+            model_name="test-model",
+            performance=perf,
+        )
+
+        table = runner.format_table()
+        assert isinstance(table, Table)
+
+    def test_save_and_load_results(self):
+        """Should save and load results from JSON."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "results.json"
+
+            # Create runner with results
+            runner = BenchmarkRunner(models=[])
+            perf = PerformanceMetrics(
+                model_name="test-model",
+                samples_count=10,
+                total_time_seconds=1.0,
+                samples_per_second=10.0,
+                avg_time_per_sample_ms=100.0,
+                peak_memory_mb=512.0,
+                embedding_dimensions=768,
+                storage_per_embedding_bytes=3072,
+                storage_per_1k_entities_mb=2.93,
+            )
+            quality = QualityMetrics(model_name="test-model", overall_score=0.85)
+            runner.results["test-model"] = BenchmarkResult(
+                model_name="test-model",
+                performance=perf,
+                quality=quality,
+            )
+
+            # Save
+            runner.save_results(path)
+            assert path.exists()
+
+            # Load
+            loaded = BenchmarkRunner.load_results(path)
+            assert "test-model" in loaded.results
+            assert loaded.results["test-model"].performance.samples_per_second == 10.0
+            assert loaded.results["test-model"].quality.overall_score == 0.85
+
+
+class TestQualityScoreFormatting:
+    """Tests for quality score formatting."""
+
+    def test_format_quality_score_none(self):
+        """Should handle None quality."""
+        runner = BenchmarkRunner(models=[])
+        result = runner._format_quality_score(None)
+        assert result == "N/A"
+
+    def test_format_quality_score_high(self):
+        """High score should get many stars."""
+        runner = BenchmarkRunner(models=[])
+        quality = QualityMetrics(model_name="test", overall_score=0.95)
+        result = runner._format_quality_score(quality)
+        assert "⭐" in result
+        assert result.count("⭐") >= 4
+
+    def test_format_quality_score_low(self):
+        """Low score should get few stars."""
+        runner = BenchmarkRunner(models=[])
+        quality = QualityMetrics(model_name="test", overall_score=0.2)
+        result = runner._format_quality_score(quality)
+        assert "⭐" in result
+        assert result.count("⭐") <= 2
+
+
+class TestPerformanceFormatting:
+    """Tests for performance metric formatting."""
+
+    def test_format_speed_none(self):
+        """Should handle None performance."""
+        runner = BenchmarkRunner(models=[])
+        result = runner._format_speed(None)
+        assert result == "N/A"
+
+    def test_format_speed_api_model(self):
+        """API models should show 'API'."""
+        runner = BenchmarkRunner(models=[])
+        perf = PerformanceMetrics(
+            model_name="test",
+            samples_count=10,
+            total_time_seconds=1.0,
+            samples_per_second=10.0,
+            avg_time_per_sample_ms=100.0,
+            peak_memory_mb=0.0,
+            embedding_dimensions=1024,
+            storage_per_embedding_bytes=4096,
+            storage_per_1k_entities_mb=3.91,
+            is_api_model=True,
+        )
+        result = runner._format_speed(perf)
+        assert result == "API"
+
+    def test_format_speed_local_model(self):
+        """Local models should show samples/sec."""
+        runner = BenchmarkRunner(models=[])
+        perf = PerformanceMetrics(
+            model_name="test",
+            samples_count=10,
+            total_time_seconds=1.0,
+            samples_per_second=15.5,
+            avg_time_per_sample_ms=64.5,
+            peak_memory_mb=512.0,
+            embedding_dimensions=768,
+            storage_per_embedding_bytes=3072,
+            storage_per_1k_entities_mb=2.93,
+            is_api_model=False,
+        )
+        result = runner._format_speed(perf)
+        assert "15.5" in result
+        assert "/s" in result
+
+    def test_format_memory_api_model(self):
+        """API models should show 'N/A' for memory."""
+        runner = BenchmarkRunner(models=[])
+        perf = PerformanceMetrics(
+            model_name="test",
+            samples_count=10,
+            total_time_seconds=1.0,
+            samples_per_second=10.0,
+            avg_time_per_sample_ms=100.0,
+            peak_memory_mb=0.0,
+            embedding_dimensions=1024,
+            storage_per_embedding_bytes=4096,
+            storage_per_1k_entities_mb=3.91,
+            is_api_model=True,
+        )
+        result = runner._format_memory(perf)
+        assert result == "N/A"


### PR DESCRIPTION
## Summary
- Add `codesearch benchmark-models` CLI command to compare embedding models
- Measure quality metrics (same-function similarity, cross-language similarity)
- Measure performance metrics (speed, memory, storage)
- Support table and JSON output formats

## Changes

### New Benchmarks Module
- **quality.py**: Quality test suite with code pairs for evaluating embedding quality
- **performance.py**: Performance profiling with memory tracking
- **runner.py**: Orchestrates benchmarks and formats output

### CLI Command
```bash
# Benchmark all local models
codesearch benchmark-models

# Benchmark specific models
codesearch benchmark-models --models codebert,unixcoder

# JSON output with save
codesearch benchmark-models --format json --save results.json
```

### Options
- `--models/-m`: Models to benchmark (default: all local)
- `--samples/-s`: Custom code samples directory
- `--format/-f`: Output format (table/json)
- `--skip-quality`: Skip quality tests
- `--skip-performance`: Skip performance tests
- `--include-api`: Include API models
- `--save`: Save results to file

## Test plan
- [x] 50 tests for quality, performance, and runner modules
- [x] Tests for scoring, formatting, save/load
- [x] All tests passing

## Example Output
```
┌────────────────────────────────────────────────────────────────────┐
│                    Embedding Model Benchmark Results               │
├─────────────┬──────────┬──────────┬───────────┬─────────────────┤
│ Model       │ Quality  │ Speed    │ Memory    │ Storage/1K      │
├─────────────┼──────────┼──────────┼───────────┼─────────────────┤
│ codebert    │ ⭐⭐⭐     │ 15.0/s   │ 512 MB    │ 2.9 MB          │
│ unixcoder   │ ⭐⭐⭐⭐    │ 14.5/s   │ 520 MB    │ 2.9 MB          │
│ codet5p-110m│ ⭐⭐⭐⭐    │ 18.0/s   │ 440 MB    │ 1.0 MB          │
└─────────────┴──────────┴──────────┴───────────┴─────────────────┘
```

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)