### PR TITLE
feat(lancedb): handle embedding model migration and re-indexing (#73)

### DIFF
--- a/codesearch/cli/main.py
+++ b/codesearch/cli/main.py
@@ -9,7 +9,7 @@ from typing import Annotated, Optional
 from codesearch import __version__
 from codesearch.cli.commands import (
     pattern, find_similar, dependencies, index, refactor_dupes, list_functions,
-    repo_list, repo_add, repo_remove, search_multi, benchmark_models
+    repo_list, repo_add, repo_remove, search_multi, benchmark_models, reindex, model_info
 )
 from codesearch.cli.interactive import (
     detail, context, compare, config_show, config_init
@@ -71,6 +71,10 @@ app.command(name="search-multi")(search_multi)
 
 # Register benchmark commands
 app.command(name="benchmark-models")(benchmark_models)
+
+# Register model migration commands
+app.command(name="reindex")(reindex)
+app.command(name="model-info")(model_info)
 
 
 def run() -> None:

--- a/codesearch/lancedb/__init__.py
+++ b/codesearch/lancedb/__init__.py
@@ -12,7 +12,12 @@ from codesearch.lancedb.models import (
 )
 from codesearch.lancedb.client import LanceDBClient
 from codesearch.lancedb.pool import DatabaseConnectionPool
-from codesearch.lancedb.initialization import DatabaseInitializer
+from codesearch.lancedb.initialization import (
+    DatabaseInitializer,
+    DimensionMismatchError,
+    EmbeddingModelInfo,
+    ModelMismatchError,
+)
 from codesearch.lancedb.backup import DatabaseBackupManager
 from codesearch.lancedb.statistics import DatabaseStatistics
 from codesearch.lancedb.optimization import DatabaseOptimizer
@@ -35,4 +40,8 @@ __all__ = [
     "DatabaseBackupManager",
     "DatabaseStatistics",
     "DatabaseOptimizer",
+    # Errors
+    "DimensionMismatchError",
+    "EmbeddingModelInfo",
+    "ModelMismatchError",
 ]


### PR DESCRIPTION
## Summary
Implements model migration support for safely switching between embedding models. When users change models, the existing indexed data becomes incompatible - this PR detects mismatches and provides clear guidance.

## Problem Solved
Different embedding models produce:
1. Different vector dimensions (768 vs 256 vs 1024)
2. Different embedding spaces (vectors from different models aren't comparable)
3. Incompatible similarity scores

Using embeddings from one model to search with another produces garbage results. This PR detects these issues early and provides clear options to users.

## Changes

### Database Initialization (`codesearch/lancedb/initialization.py`)
- Added `EmbeddingModelInfo` dataclass for model metadata storage
- Added `ModelMismatchError` and `DimensionMismatchError` exceptions
- `set_embedding_model()` stores model name, path, dimensions, entity count, timestamp
- `get_embedding_model()` retrieves model metadata from db_config.json
- `check_model_compatibility()` validates requested model against indexed model
- `clear_for_reindex()` drops tables and config for clean re-indexing
- `update_entity_count()` updates entity count in model metadata

### CLI Commands (`codesearch/cli/commands.py`, `main.py`)
- **search**: Added `--model/-m` flag to specify query model
  - Auto-detects indexed model and uses it if available
  - Warns on model mismatch with same dimensions (suboptimal results)
  - Blocks search on dimension mismatch with helpful error message
- **index**: Enhanced model mismatch detection
  - Shows conflict when database indexed with different model
  - `--force` flag now properly clears database before re-indexing
  - Stores model metadata after successful indexing
- **reindex**: New command for switching embedding models
  - Shows current model info and target model
  - Confirmation prompt (skippable with `--yes`)
  - Clears database and delegates to index command
- **model-info**: New command to show indexed model metadata

### Query Engine (`codesearch/query/engine.py`)
- Added dimension validation in `search_vector()`
- Raises `DimensionMismatchError` if query vector dimensions don't match

## Example Usage

```bash
# Check current indexed model
codesearch model-info

# Search with specific model
codesearch search "error handling" --model codebert

# Re-index with new model
codesearch reindex --model unixcoder

# Force re-index (skips confirmation)
codesearch reindex /path/to/repo --model codet5p-110m --yes

# Index with force flag
codesearch index . --force --model unixcoder
```

## Warning Messages

When model mismatch is detected:
```
⚠️  Model mismatch detected!

   Database indexed with: codebert (768 dims)
   Requested model:       codet5p-110m (256 dims)

   Options:
   1. Re-index with new model: codesearch index . --force --model codet5p-110m
   2. Search with original model: codesearch search "query" --model codebert
   3. Keep existing index (not recommended for model changes)
```

## Test Plan
- [x] 15 new tests for model migration scenarios
- [x] Tests for EmbeddingModelInfo serialization/deserialization
- [x] Tests for compatibility checking (same model, different dims, same dims different model)
- [x] Tests for clear_for_reindex
- [x] Tests for error classes
- [x] All 54 lancedb tests pass
- [x] Linting passes

## Acceptance Criteria
- [x] Model metadata stored in database
- [x] Mismatch detection on search/index
- [x] Clear warning messages
- [x] `--force` flag for re-indexing
- [x] `reindex` command with confirmation
- [x] Dimension mismatch error handling
- [x] Tests for migration scenarios

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)