### PR TITLE
feat(cli): add MLX model support to CLI commands (#85)

### DIFF
--- a/codesearch/cli/main.py
+++ b/codesearch/cli/main.py
@@ -4,15 +4,33 @@ This module provides the main CLI interface using Typer framework.
 Supports semantic code search, analysis, and indexing operations.
 """
 
-import typer
 from typing import Annotated, Optional
+
+import typer
+
 from codesearch import __version__
 from codesearch.cli.commands import (
-    pattern, find_similar, dependencies, index, refactor_dupes, list_functions,
-    repo_list, repo_add, repo_remove, search_multi, benchmark_models, reindex, model_info
+    benchmark_models,
+    dependencies,
+    find_similar,
+    index,
+    list_functions,
+    list_models,
+    model_info,
+    pattern,
+    refactor_dupes,
+    reindex,
+    repo_add,
+    repo_list,
+    repo_remove,
+    search_multi,
 )
 from codesearch.cli.interactive import (
-    detail, context, compare, config_show, config_init
+    compare,
+    config_init,
+    config_show,
+    context,
+    detail,
 )
 
 
@@ -75,6 +93,7 @@ app.command(name="benchmark-models")(benchmark_models)
 # Register model migration commands
 app.command(name="reindex")(reindex)
 app.command(name="model-info")(model_info)
+app.command(name="list-models")(list_models)
 
 
 def run() -> None:


### PR DESCRIPTION
## Summary
- Added `list-models` command showing all available embedding models with backend info (PyTorch/MLX/API)
- Added `_check_mlx_availability()` helper to warn users when MLX models are selected on non-Apple Silicon
- Added `--skip-mlx` flag to `benchmark-models` command for running on non-Apple hardware
- Updated BenchmarkRunner with `skip_mlx_models` filtering support
- Added 10 comprehensive tests for the new functionality

## Test plan
- [x] Run `codesearch list-models` to verify table output shows all models with correct backend types
- [x] Run `codesearch benchmark-models --skip-mlx` to verify MLX models are excluded
- [x] Verify `_check_mlx_availability` returns warnings on non-Apple Silicon
- [x] Run full test suite: `pytest tests/cli/test_commands.py -v -k "ListModels or MLXAvailability or BenchmarkModelsSkipMLX"`

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)